### PR TITLE
refactor: fix casing of WiCAN

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This is the official HA integration for [WiCan](https://github.com/meatpiHQ/wican-fw).
+This is the official HA integration for [WiCAN](https://github.com/meatpiHQ/wican-fw).
 
 It is very much in an Alpha stage at the moment, and under constant changes, hoping to get it in a Beta state soon where we could recommend starting to use it.
  

--- a/custom_components/wican/config_flow.py
+++ b/custom_components/wican/config_flow.py
@@ -23,15 +23,15 @@ class WiCanConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 info = await wican.test()
 
                 if info:
-                    return self.async_create_entry(title="WiCan", data=user_input)
+                    return self.async_create_entry(title="WiCAN", data=user_input)
                 else:
                     errors[CONF_IP_ADDRESS] = "Failed validation, double check the IP, as well as check if you have protocol set to auto_pid"
             except ConnectionError:
                 _LOGGER.exception("Connection Error")
-                errors[CONF_IP_ADDRESS] = "WiCan Connection error, are you sure the IP is correct?"
+                errors[CONF_IP_ADDRESS] = "WiCAN Connection error, are you sure the IP is correct?"
             except Exception:
                 _LOGGER.exception("Unexpected exception")
-                errors[CONF_IP_ADDRESS] = "WiCan not validated, unknown error"
+                errors[CONF_IP_ADDRESS] = "WiCAN not validated, unknown error"
                 
         return self.async_show_form(
             step_id="user", data_schema=DATA_SCHEMA, errors=errors

--- a/custom_components/wican/manifest.json
+++ b/custom_components/wican/manifest.json
@@ -1,6 +1,6 @@
 {
     "domain": "wican",
-    "name": "WiCan",
+    "name": "WiCAN",
     "dependencies": ["http"],
     "codeowners": ["@jay-oswald"],
     "version": "0.1.2",

--- a/custom_components/wican/sensor.py
+++ b/custom_components/wican/sensor.py
@@ -108,7 +108,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 def device_info(coordinator):
     return {
         "identifiers": {(DOMAIN, coordinator.data['status']['device_id'])},
-        "name": "WiCan",
+        "name": "WiCAN",
         "manufacturer": "MeatPi",
         "model": coordinator.data['status']['hw_version'],
         "configuration_url": "http://" + coordinator.data['status']['sta_ip'],
@@ -196,7 +196,7 @@ class WiCanCoordinator(DataUpdateCoordinator):
         super().__init__(
             hass,
             _LOGGER,
-            name="WiCan Coordinator",
+            name="WiCAN Coordinator",
             update_interval = timedelta(seconds=30)
         )
 

--- a/custom_components/wican/strings.json
+++ b/custom_components/wican/strings.json
@@ -2,8 +2,8 @@
     "config": {
         "step": {
             "user": {
-                "title": "Config for WiCan Integration",
-                "description": "Please make sure you are using a static IP address for your WiCan, we do not support dynamic IP addresses yet.",
+                "title": "Config for WiCAN Integration",
+                "description": "Please make sure you are using a static IP address for your WiCAN, we do not support dynamic IP addresses yet.",
                 "data": {
                     "ip": "IP Address"
                 }

--- a/custom_components/wican/translations/en.json
+++ b/custom_components/wican/translations/en.json
@@ -2,10 +2,10 @@
     "config": {
         "step": {
             "user": {
-                "title": "Config for WiCan Integration",
-                "description": "Enter the IP Address for your WiCan. Please make sure your protocol is also set to auto_pid",
+                "title": "Config for WiCAN Integration",
+                "description": "Enter the IP Address for your WiCAN. Please make sure your protocol is also set to auto_pid",
                 "data": {
-                    "ip": "WiCan IP"
+                    "ip": "WiCAN IP"
                 }
             }
         }


### PR DESCRIPTION
Updates `WiCan` to `WiCAN` in all user-facing strings. This MR does not refactor any python class or function names. This can be done at a later date before `v1`.

Fixes #3 