### PR TITLE
Skip sensor type, if not explicitly set.

### DIFF
--- a/custom_components/wican/binary_sensor.py
+++ b/custom_components/wican/binary_sensor.py
@@ -76,17 +76,18 @@ async def async_setup_entry(hass, entry, async_add_entities):
         return async_add_entities(entities)
 
     for key in coordinator.data["pid"]:
-        if coordinator.data["pid"][key]["sensor_type"] == "binary_sensor":
-            entities.append(
-                WiCanPidEntity(
-                    coordinator,
-                    {
-                        "key": key,
-                        "name": key,
-                        "class": coordinator.data["pid"][key]["class"],
-                    },
-                    binary_state("on"),
+        if coordinator.data["pid"][key].get("sensor_type") is not None:
+            if coordinator.data["pid"][key]["sensor_type"] == "binary_sensor":
+                entities.append(
+                    WiCanPidEntity(
+                        coordinator,
+                        {
+                            "key": key,
+                            "name": key,
+                            "class": coordinator.data["pid"][key]["class"],
+                        },
+                        binary_state("on"),
+                    )
                 )
-            )
 
     return async_add_entities(entities)

--- a/custom_components/wican/coordinator.py
+++ b/custom_components/wican/coordinator.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
 )
+from homeassistant.exceptions import ConfigEntryNotReady
 
 from .const import DOMAIN
 
@@ -29,7 +30,7 @@ class WiCanCoordinator(DataUpdateCoordinator):
         data = {}
         data["status"] = await self.api.check_status()
         if data["status"] == False:
-            return data
+            raise ConfigEntryNotReady("cannot_connect")
 
         self.ecu_online = True
         # self.ecu_online = data['status']['ecu_status'] == 'online'

--- a/custom_components/wican/entity.py
+++ b/custom_components/wican/entity.py
@@ -45,7 +45,7 @@ class WiCanEntityBase(CoordinatorEntity):
 
     def set_state(self):
         new_state = self.get_new_state()
-        if not new_state:
+        if new_state is None:
             return
 
         if self.process_state is not None:

--- a/custom_components/wican/entity.py
+++ b/custom_components/wican/entity.py
@@ -71,11 +71,17 @@ class WiCanEntityBase(CoordinatorEntity):
 
     @property
     def unit_of_measurement(self):
-        return self.get_data("unit")
+        if self.get_data("unit") == "none":
+            return None
+        else:
+            return self.get_data("unit")
 
     @property
     def device_class(self):
-        return self.get_data("class")
+        if self.get_data("class") == "none":
+            return None
+        else:
+            return self.get_data("class")
 
 
 class WiCanStatusEntity(WiCanEntityBase):

--- a/custom_components/wican/sensor.py
+++ b/custom_components/wican/sensor.py
@@ -60,7 +60,14 @@ async def async_setup_entry(hass, entry, async_add_entities):
         return async_add_entities(entities)
 
     for key in coordinator.data["pid"]:
-        if coordinator.data["pid"][key]["sensor_type"] != "binary_sensor":
+        append = False
+        if coordinator.data["pid"][key].get("sensor_type") is not None:
+            if coordinator.data["pid"][key]["sensor_type"] != "binary_sensor":
+                append = True
+        else:
+            append = True
+
+        if append:
             entities.append(
                 WiCanPidEntity(
                     coordinator,

--- a/custom_components/wican/wican.py
+++ b/custom_components/wican/wican.py
@@ -1,24 +1,29 @@
 import aiohttp
 import logging
+
 _LOGGER = logging.getLogger(__name__)
 
-class WiCan:
-    ip = "";
-    def __init__(self, ip):
-        self.ip = ip;
 
-    async def call(self, endpoint, params = {}, method="get"):
+class WiCan:
+    ip = ""
+
+    def __init__(self, ip):
+        self.ip = ip
+
+    async def call(self, endpoint, params={}, method="get"):
         match method:
             case "get":
                 async with aiohttp.ClientSession() as session:
-                    async with session.get("http://" + self.ip + endpoint, params=params) as resp:
+                    async with session.get(
+                        "http://" + self.ip + endpoint, params=params
+                    ) as resp:
                         resp.data = await resp.json(content_type=None)
                         return resp
 
     async def test(self) -> bool:
         result = await self.call("/check_status")
-        
-        return result.status == 200 and result.data['protocol'] == "auto_pid"
+
+        return result.status == 200 and result.data["protocol"] == "auto_pid"
 
     async def check_status(self):
         try:
@@ -26,9 +31,9 @@ class WiCan:
         except:
             return False
 
-        if(not result.status == 200):
+        if not result.status == 200:
             return False
-        
+
         return result.data
 
     async def get_pid(self):
@@ -41,11 +46,10 @@ class WiCan:
         if not isinstance(pid_meta.data, dict):
             return False
 
-        result = {};
+        result = {}
         for key in pid_meta.data:
             result[key] = pid_meta.data[key]
             value = pid_data.data[key] if key in pid_data.data else False
             result[key]["value"] = value
 
         return result
-


### PR DESCRIPTION
Hi @jay-oswald,

this PR fixes the issue discussed in #10.
If sensor_type is not set, it will be ignored.
Binary sensors will only get added, if explicity set as sensor_type.

Furthermore this PR fixes sensor values "0", which were not added before.
As well it handles sensor class and unit of measure "none" coming from the API correctly.