### PR TITLE
en.json: Use AutoPID rather than auto_pid

### DIFF
--- a/custom_components/wican/translations/en.json
+++ b/custom_components/wican/translations/en.json
@@ -1,14 +1,14 @@
 {
     "config": {
         "error": {
-            "invalid_config": "Failed validation, double check the IP, as well as check if you have protocol set to auto_pid",
+            "invalid_config": "Failed validation, double check the IP, as well as check if you have protocol set to AutoPID",
             "cannot_connect": "WiCAN Connection error, are you sure the IP is correct?",
             "unknown": "WiCAN not validated, unknown error"
         },
         "step": {
             "user": {
                 "title": "Config for WiCAN Integration",
-                "description": "Enter the IP-Address for your WiCAN device. It should be static or fixed in your router to avoid connection issues. Please also make sure your protocol is set to 'auto_pid'. If you need help setting it up, you can find it here: https://github.com/jay-oswald/ha-wican",
+                "description": "Enter the IP-Address for your WiCAN device. It should be static or fixed in your router to avoid connection issues. Please also make sure your protocol is set to 'AutoPID'. If you need help setting it up, you can find it here: https://github.com/jay-oswald/ha-wican",
                 "data": {
                     "ip_address": "WiCAN IP-Address",
                     "scan_interval": "Polling Interval in seconds [min: 5sec]"


### PR DESCRIPTION
As per https://github.com/meatpiHQ/wican-fw/blob/b4509d82e8da331992492b750d9c5e0ce00fc779/main/homepage_full.html#L638, it's shown as `AutoPID` not `auto_pid` in the UI