### PR TITLE
Offline‑tolerant WiCAN

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,22 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest pytest-asyncio
+      - name: Run tests
+        env:
+          PYTHONPATH: .
+        run: pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,28 @@ config/
 
 #PY Cache
 custom_components/wican/__pycache__/*
+# General
+.DS_Store
+__MACOSX/
+.AppleDouble
+.LSOverride
+Icon[]
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,8 @@ custom_components/wican/__pycache__/*
 __MACOSX/
 .AppleDouble
 .LSOverride
-Icon[]
+Icon[
+]
 
 # Thumbnails
 ._*
@@ -28,3 +29,220 @@ Icon[]
 Network Trash Folder
 Temporary Items
 .apdisk
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[codz]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#   Usually these files are written by a python script from a template
+#   before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py.cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+# Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+# uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+# poetry.lock
+# poetry.toml
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#   pdm recommends including project-wide configuration in pdm.toml, but excluding .pdm-python.
+#   https://pdm-project.org/en/latest/usage/project/#working-with-version-control
+# pdm.lock
+# pdm.toml
+.pdm-python
+.pdm-build/
+
+# pixi
+#   Similar to Pipfile.lock, it is generally recommended to include pixi.lock in version control.
+# pixi.lock
+#   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one
+#   in the .venv directory. It is recommended not to include this directory in version control.
+.pixi
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# Redis
+*.rdb
+*.aof
+*.pid
+
+# RabbitMQ
+mnesia/
+rabbitmq/
+rabbitmq-data/
+
+# ActiveMQ
+activemq-data/
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.envrc
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#   JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#   be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#   and can be added to the global gitignore or merged into this file.  For a more nuclear
+#   option (not recommended) you can uncomment the following to ignore the entire idea folder.
+# .idea/
+
+# Abstra
+#   Abstra is an AI-powered process automation framework.
+#   Ignore directories containing user credentials, local state, and settings.
+#   Learn more at https://abstra.io/docs
+.abstra/
+
+# Visual Studio Code
+#   Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#   that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
+#   and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#   you could uncomment the following to ignore the entire vscode folder
+# .vscode/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+# Marimo
+marimo/_static/
+marimo/_lsp/
+__marimo__/
+
+# Streamlit
+.streamlit/secrets.toml

--- a/README.md
+++ b/README.md
@@ -17,6 +17,17 @@ There you will also find configuration instructions for the device itself (e.g. 
 # Integration Status
 It is very much in an Alpha stage at the moment, and under constant changes, hoping to get it in a Beta state soon where we could recommend starting to use it.
 
+# Offline, Restore, and Freshness
+- Snapshot caching: The integration stores a minimal snapshot of the last-known data (device status and PIDs). On restart while the device is offline, entities are created from this snapshot so your dashboard does not go empty.
+- Stale indicator: Entities include extra attributes to indicate freshness:
+  - `wican_data_stale`: true when values are coming from cache/memory while the device is offline.
+  - `last_successful_update`: ISO8601 timestamp of the last successful update, or null if none yet.
+- Availability: Entities remain available while stale; use the `wican_data_stale` attribute to drive UI/display.
+- First install while offline: On a brand‑new install with no snapshot yet and the device unreachable, setup defers with a retry (it won’t crash Home Assistant). Once the device is reachable or a snapshot exists, setup proceeds.
+
+# Network Robustness
+- All HTTP calls use bounded timeouts (default ~5s) with robust exception handling. Temporary network errors won’t crash the integration; they trigger the stale/snapshot fallback instead.
+
 # Installation
 
 ## Manual Installation
@@ -40,6 +51,10 @@ It is very much in an Alpha stage at the moment, and under constant changes, hop
 - Enter the mDNS/hostname (wican_xxxxxxxxxxxx.local) or IP-Address of WiCAN device to connect the WiCAN device. If you have multiple WiCAN devices repeat these steps for the other devices.
 
 Result: After completing installation and configuration, WiCAN will be connected to Home Assistant, and you will be able to monitor the available car parameters directly from the Home Assistant interface.
+
+# Development and Tests
+- Quickstart: `python -m venv .venv && source .venv/bin/activate && pip install pytest pytest-asyncio && PYTHONPATH=. pytest -q`
+- A CI workflow runs the test suite on every PR/push as a separate check.
 
 # Troubleshooting
 ### Not possible to add a device via IP-Address or mDNS/hostname

--- a/custom_components/wican/wican.py
+++ b/custom_components/wican/wican.py
@@ -1,8 +1,13 @@
-"""Communicate with WiCAN device HTTP-API via available endpoints."""
+"""Communicate with WiCAN device HTTP-API via available endpoints.
+
+Adds bounded timeouts and robust exception handling so callers can
+reliably detect unreachable devices and trigger stale/snapshot fallback.
+"""
 
 import logging
 
 import aiohttp
+import asyncio
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -23,7 +28,7 @@ class WiCan:
         """Initialize the WiCan API integration with the device IP / name."""
         self.ip = ip
 
-    async def call(self, endpoint, params=None, method="get"):
+    async def call(self, endpoint, params=None, method="get", timeout_total: float = 5.0):
         """Call WiCan device HTTP-API endpoint and provide response.
 
         Parameters
@@ -43,14 +48,22 @@ class WiCan:
         """
         if params is None:
             params = {}
-        match method:
-            case "get":
-                async with aiohttp.ClientSession() as session:
-                    async with session.get(
-                        "http://" + self.ip + endpoint, params=params
-                    ) as resp:
+        url = "http://" + self.ip + endpoint
+        try:
+            timeout = aiohttp.ClientTimeout(total=timeout_total)
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                if method.lower() == "get":
+                    async with session.get(url, params=params) as resp:
                         resp.data = await resp.json(content_type=None)
                         return resp
+                else:
+                    # Fallback to GET for unsupported methods in this client
+                    async with session.get(url, params=params) as resp:
+                        resp.data = await resp.json(content_type=None)
+                        return resp
+        except (aiohttp.ClientError, asyncio.TimeoutError, OSError) as err:
+            _LOGGER.debug("WiCAN API call failed for %s: %s", url, err)
+            raise
 
     async def test(self) -> bool:
         """Test, if the WiCan device API is reachable and the protocal is set to "auto_pid".
@@ -61,9 +74,13 @@ class WiCan:
             Returns True, if the API is reachable and the WiCan protocol is set to "auto_pid". Otherwise returns False.
 
         """
-        result = await self.call("/check_status")
+        try:
+            result = await self.call("/check_status")
+        except (aiohttp.ClientError, asyncio.TimeoutError, OSError) as err:
+            _LOGGER.debug("WiCAN test failed: %s", err)
+            return False
 
-        return result.status == 200 and result.data["protocol"] == "auto_pid"
+        return result.status == 200 and result.data.get("protocol") == "auto_pid"
 
     async def check_status(self):
         """Check, if the WiCan device API is reachable.
@@ -76,7 +93,8 @@ class WiCan:
         """
         try:
             result = await self.call("/check_status")
-        except:
+        except (aiohttp.ClientError, asyncio.TimeoutError, OSError) as err:
+            _LOGGER.debug("WiCAN check_status failed: %s", err)
             return False
 
         if result.status != 200:
@@ -96,7 +114,8 @@ class WiCan:
         try:
             pid_data = await self.call("/autopid_data")
             pid_meta = await self.call("/load_car_config")
-        except:
+        except (aiohttp.ClientError, asyncio.TimeoutError, OSError) as err:
+            _LOGGER.debug("WiCAN get_pid failed: %s", err)
             return False
 
         if not isinstance(pid_meta.data, dict):

--- a/tests/test_api_timeouts.py
+++ b/tests/test_api_timeouts.py
@@ -1,0 +1,238 @@
+import sys
+import types
+import asyncio
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+import importlib.util
+import os
+
+
+def load_wican_module():
+    # Stub aiohttp to avoid real dependency
+    aiohttp_mod = types.ModuleType("aiohttp")
+
+    class ClientError(Exception):
+        pass
+
+    class ClientTimeout:
+        def __init__(self, total=None):
+            self.total = total
+
+    class ClientSession:
+        def __init__(self, timeout=None):
+            self.timeout = timeout
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        def get(self, *args, **kwargs):
+            class _Resp:
+                async def __aenter__(self_inner):
+                    return self_inner
+
+                async def __aexit__(self_inner, exc_type, exc, tb):
+                    return False
+
+                async def json(self, content_type=None):
+                    return {}
+
+                @property
+                def status(self):
+                    return 200
+
+            return _Resp()
+
+    aiohttp_mod.ClientError = ClientError
+    aiohttp_mod.ClientTimeout = ClientTimeout
+    aiohttp_mod.ClientSession = ClientSession
+    sys.modules["aiohttp"] = aiohttp_mod
+
+    # Load module from file
+    repo_root = os.path.dirname(os.path.dirname(__file__))
+    name = "custom_components.wican.wican"
+    file_path = os.path.join(repo_root, "custom_components", "wican", "wican.py")
+    spec = importlib.util.spec_from_file_location(name, file_path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    assert spec and spec.loader
+    spec.loader.exec_module(mod)  # type: ignore[attr-defined]
+    return mod
+
+
+@pytest.mark.asyncio
+async def test_check_status_timeout_returns_false(monkeypatch):
+    wican_mod = load_wican_module()
+    WiCan = getattr(wican_mod, "WiCan")
+    api = WiCan("1.2.3.4")
+
+    async def raise_timeout(*args, **kwargs):
+        raise asyncio.TimeoutError()
+
+    monkeypatch.setattr(api, "call", raise_timeout, raising=True)
+
+    ok = await api.check_status()
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_get_pid_timeout_returns_false(monkeypatch):
+    wican_mod = load_wican_module()
+    WiCan = getattr(wican_mod, "WiCan")
+    api = WiCan("1.2.3.4")
+
+    async def raise_timeout(*args, **kwargs):
+        raise asyncio.TimeoutError()
+
+    monkeypatch.setattr(api, "call", raise_timeout, raising=True)
+
+    ok = await api.get_pid()
+    assert ok is False
+
+
+def load_coordinator_module():
+    # Minimal HA stubs required by coordinator
+    ha_pkg = types.ModuleType("homeassistant")
+    const_mod = types.ModuleType("homeassistant.const")
+    const_mod.CONF_SCAN_INTERVAL = "scan_interval"
+    const_mod.CONF_IP_ADDRESS = "ip_address"
+    class Platform:
+        BINARY_SENSOR = "binary_sensor"
+        SENSOR = "sensor"
+    const_mod.Platform = Platform
+
+    core_mod = types.ModuleType("homeassistant.core")
+    class HomeAssistant:
+        pass
+    def callback(func):
+        return func
+    core_mod.HomeAssistant = HomeAssistant
+    core_mod.callback = callback
+
+    exceptions_mod = types.ModuleType("homeassistant.exceptions")
+    class ConfigEntryNotReady(Exception):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args)
+    exceptions_mod.ConfigEntryNotReady = ConfigEntryNotReady
+
+    helpers_pkg = types.ModuleType("homeassistant.helpers")
+    helpers_update_coordinator_mod = types.ModuleType("homeassistant.helpers.update_coordinator")
+    class DataUpdateCoordinator:
+        def __init__(self, *a, **kw):
+            self.data = {}
+    class CoordinatorEntity:
+        def __init__(self, coordinator) -> None:
+            self.coordinator = coordinator
+        async def async_added_to_hass(self):
+            pass
+        def async_write_ha_state(self):
+            pass
+    helpers_update_coordinator_mod.DataUpdateCoordinator = DataUpdateCoordinator
+    helpers_update_coordinator_mod.CoordinatorEntity = CoordinatorEntity
+
+    helpers_storage_mod = types.ModuleType("homeassistant.helpers.storage")
+    class Store:
+        def __init__(self, hass, version: int, key: str):
+            self.hass = hass
+            self.version = version
+            self.key = key
+            self.data = None
+        async def async_load(self):
+            return self.data
+        async def async_save(self, data):
+            self.data = data
+    helpers_storage_mod.Store = Store
+
+    util_pkg = types.ModuleType("homeassistant.util")
+    dt_mod = types.ModuleType("homeassistant.util.dt")
+    from datetime import datetime, timezone
+    def utcnow():
+        return datetime.now(timezone.utc)
+    def parse_datetime(s: str):
+        try:
+            return datetime.fromisoformat(s.replace("Z", "+00:00"))
+        except Exception:
+            return None
+    dt_mod.utcnow = utcnow
+    dt_mod.parse_datetime = parse_datetime
+
+    sys.modules["homeassistant"] = ha_pkg
+    sys.modules["homeassistant.const"] = const_mod
+    sys.modules["homeassistant.core"] = core_mod
+    sys.modules["homeassistant.exceptions"] = exceptions_mod
+    sys.modules["homeassistant.helpers"] = helpers_pkg
+    sys.modules["homeassistant.helpers.update_coordinator"] = helpers_update_coordinator_mod
+    sys.modules["homeassistant.helpers.storage"] = helpers_storage_mod
+    sys.modules["homeassistant.util"] = util_pkg
+    sys.modules["homeassistant.util.dt"] = dt_mod
+
+    # Create package shells to avoid importing __init__.py
+    repo_root = os.path.dirname(os.path.dirname(__file__))
+    cc_pkg = sys.modules.setdefault("custom_components", types.ModuleType("custom_components"))
+    if not hasattr(cc_pkg, "__path__"):
+        cc_pkg.__path__ = [os.path.join(repo_root, "custom_components")]
+    wican_pkg = sys.modules.setdefault("custom_components.wican", types.ModuleType("custom_components.wican"))
+    wican_pkg.__path__ = [os.path.join(repo_root, "custom_components", "wican")]
+
+    # Load coordinator
+    name = "custom_components.wican.coordinator"
+    file_path = os.path.join(repo_root, "custom_components", "wican", "coordinator.py")
+    spec = importlib.util.spec_from_file_location(name, file_path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    assert spec and spec.loader
+    spec.loader.exec_module(mod)  # type: ignore[attr-defined]
+    return mod
+
+
+class DummyEntry:
+    def __init__(self, entry_id: str = "e1"):
+        self.entry_id = entry_id
+        self.data = {}
+        self.options = {}
+
+
+@pytest.mark.asyncio
+async def test_coordinator_stale_on_timeout(monkeypatch):
+    # Load modules
+    wican_mod = load_wican_module()
+    WiCan = getattr(wican_mod, "WiCan")
+    coord_mod = load_coordinator_module()
+    WiCanCoordinator = getattr(coord_mod, "WiCanCoordinator")
+
+    # Build API and coordinator
+    api = WiCan("1.2.3.4")
+    hass = object()
+    coordinator = WiCanCoordinator(hass, DummyEntry(), api)
+
+    # First, populate memory with success without hitting network
+    status_ok = {"device_id": "devT", "ecu_status": "online", "hw_version": "1", "sta_ip": "1.2.3.4", "fw_version": "1"}
+    pid_ok = {"A": {"class": "none", "unit": "none", "value": 1}}
+
+    async def fake_status():
+        return status_ok
+
+    async def fake_pid():
+        return pid_ok
+
+    monkeypatch.setattr(api, "check_status", fake_status, raising=True)
+    monkeypatch.setattr(api, "get_pid", fake_pid, raising=True)
+    coordinator.data = await coordinator.get_data()
+
+    # Now cause timeouts by raising from call (used by real check_status)
+    async def raise_timeout(*args, **kwargs):
+        raise asyncio.TimeoutError()
+
+    # Restore real check_status and patch call to raise
+    monkeypatch.setattr(api, "call", raise_timeout, raising=True)
+    # Bind the original method to the instance
+    bound_check_status = WiCan.check_status.__get__(api, WiCan)
+    monkeypatch.setattr(api, "check_status", bound_check_status, raising=True)
+
+    data2 = await coordinator.get_data()
+    assert data2 == coordinator.data
+    assert coordinator.stale() is True

--- a/tests/test_entity_restore.py
+++ b/tests/test_entity_restore.py
@@ -1,0 +1,234 @@
+import sys
+import types
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+import importlib.util
+import os
+
+
+# Minimal HA stubs
+ha_pkg = types.ModuleType("homeassistant")
+
+const_mod = types.ModuleType("homeassistant.const")
+const_mod.CONF_SCAN_INTERVAL = "scan_interval"
+
+core_mod = types.ModuleType("homeassistant.core")
+
+
+def callback(func):
+    return func
+
+
+core_mod.callback = callback
+core_mod.HomeAssistant = object
+
+helpers_pkg = types.ModuleType("homeassistant.helpers")
+helpers_update_coordinator_mod = types.ModuleType(
+    "homeassistant.helpers.update_coordinator"
+)
+
+
+class DataUpdateCoordinator:
+    def __init__(self, hass=None, logger=None, name=None, update_interval=None) -> None:
+        self.hass = hass
+        self.logger = logger
+        self.name = name
+        self.update_interval = update_interval
+        self.data = {}
+
+
+class CoordinatorEntity:
+    def __init__(self, coordinator) -> None:
+        self.coordinator = coordinator
+
+    async def async_added_to_hass(self) -> None:
+        pass
+
+    def async_write_ha_state(self) -> None:
+        # no-op for tests
+        pass
+
+
+helpers_update_coordinator_mod.DataUpdateCoordinator = DataUpdateCoordinator
+helpers_update_coordinator_mod.CoordinatorEntity = CoordinatorEntity
+
+helpers_restore_state_mod = types.ModuleType("homeassistant.helpers.restore_state")
+
+
+class RestoreEntity:
+    async def async_get_last_state(self):
+        # Tests can set _fake_last_state on the entity instance
+        return getattr(self, "_fake_last_state", None)
+
+
+helpers_restore_state_mod.RestoreEntity = RestoreEntity
+
+util_pkg = types.ModuleType("homeassistant.util")
+dt_mod = types.ModuleType("homeassistant.util.dt")
+
+
+def utcnow():
+    return datetime.now(timezone.utc)
+
+
+def parse_datetime(value: str):
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except Exception:
+        return None
+
+
+dt_mod.utcnow = utcnow
+dt_mod.parse_datetime = parse_datetime
+
+# Wire stubs
+sys.modules["homeassistant"] = ha_pkg
+sys.modules["homeassistant.const"] = const_mod
+sys.modules["homeassistant.core"] = core_mod
+sys.modules["homeassistant.helpers"] = helpers_pkg
+sys.modules["homeassistant.helpers.update_coordinator"] = (
+    helpers_update_coordinator_mod
+)
+helpers_storage_mod = types.ModuleType("homeassistant.helpers.storage")
+
+
+class Store:
+    def __init__(self, hass, version: int, key: str) -> None:
+        self.hass = hass
+        self.version = version
+        self.key = key
+
+    async def async_load(self):
+        return None
+
+    async def async_save(self, data):
+        return None
+
+
+helpers_storage_mod.Store = Store
+sys.modules["homeassistant.helpers.storage"] = helpers_storage_mod
+exceptions_mod = types.ModuleType("homeassistant.exceptions")
+
+
+class ConfigEntryNotReady(Exception):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args)
+exceptions_mod.ConfigEntryNotReady = ConfigEntryNotReady
+sys.modules["homeassistant.exceptions"] = exceptions_mod
+sys.modules["homeassistant.helpers.restore_state"] = helpers_restore_state_mod
+sys.modules["homeassistant.util"] = util_pkg
+sys.modules["homeassistant.util.dt"] = dt_mod
+
+
+def load_modules():
+    repo_root = os.path.dirname(os.path.dirname(__file__))
+    # Ensure package namespace exists
+    cc_pkg = sys.modules.setdefault("custom_components", types.ModuleType("custom_components"))
+    if not hasattr(cc_pkg, "__path__"):
+        cc_pkg.__path__ = [os.path.join(repo_root, "custom_components")]
+    wican_pkg = sys.modules.setdefault("custom_components.wican", types.ModuleType("custom_components.wican"))
+    wican_pkg.__path__ = [os.path.join(repo_root, "custom_components", "wican")]
+
+    # Load coordinator first (entity imports it for type only)
+    name_coord = "custom_components.wican.coordinator"
+    file_coord = os.path.join(repo_root, "custom_components", "wican", "coordinator.py")
+    spec = importlib.util.spec_from_file_location(name_coord, file_coord)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name_coord] = mod
+    assert spec and spec.loader
+    spec.loader.exec_module(mod)  # type: ignore[attr-defined]
+
+    # Ensure the update_coordinator stub exposes CoordinatorEntity
+    ucm = sys.modules.get("homeassistant.helpers.update_coordinator")
+    if ucm is not None and not hasattr(ucm, "CoordinatorEntity"):
+        setattr(ucm, "CoordinatorEntity", CoordinatorEntity)
+
+    # Now load entity
+    name_ent = "custom_components.wican.entity"
+    file_ent = os.path.join(repo_root, "custom_components", "wican", "entity.py")
+    spec2 = importlib.util.spec_from_file_location(name_ent, file_ent)
+    mod2 = importlib.util.module_from_spec(spec2)
+    sys.modules[name_ent] = mod2
+    assert spec2 and spec2.loader
+    spec2.loader.exec_module(mod2)  # type: ignore[attr-defined]
+    return mod, mod2
+
+
+class DummyCoordinator:
+    def __init__(self) -> None:
+        self._stale = True
+        self.data = {"status": {"device_id": "dev111", "hw_version": "1", "sta_ip": "1.2.3.4", "fw_version": "1"}}
+        self._available = True
+        self.last_successful_update = None
+
+    def stale(self) -> bool:
+        return self._stale
+
+    def available(self) -> bool:
+        return self._available
+
+    def get_status(self, key):
+        return self.data["status"].get(key)
+
+    def get_pid_value(self, key):
+        return False
+
+    def device_info(self):
+        return {
+            "identifiers": {("wican", self.data["status"]["device_id"])},
+            "name": "WiCAN",
+            "manufacturer": "MeatPi",
+            "model": self.data["status"]["hw_version"],
+            "configuration_url": "http://" + self.data["status"]["sta_ip"],
+            "sw_version": self.data["status"]["fw_version"],
+            "hw_version": self.data["status"]["hw_version"],
+        }
+
+
+class LastState:
+    def __init__(self, state: str) -> None:
+        self.state = state
+
+
+@pytest.mark.asyncio
+async def test_restore_entity_state_when_stale_and_no_live_data():
+    _, entity_mod = load_modules()
+    WiCanPidEntity = getattr(entity_mod, "WiCanPidEntity")
+
+    coord = DummyCoordinator()
+    ent = WiCanPidEntity(coord, {"key": "SOC_BMS", "name": "SOC_BMS", "class": "none", "unit": "%"})
+    # No live data -> state is False; mark stale and provide last state
+    ent._fake_last_state = LastState("42")
+    await ent.async_added_to_hass()
+
+    assert ent.state == "42"
+    attrs = ent.extra_state_attributes
+    assert attrs["wican_data_stale"] is True
+    assert attrs["last_successful_update"] is None
+    # Available should be True while stale
+    assert ent.available is True
+
+
+@pytest.mark.asyncio
+async def test_entity_updates_on_fresh_data_and_metadata():
+    coord_mod, entity_mod = load_modules()
+    WiCanPidEntity = getattr(entity_mod, "WiCanPidEntity")
+
+    coord = DummyCoordinator()
+    ent = WiCanPidEntity(coord, {"key": "SOC_BMS", "name": "SOC_BMS", "class": "none", "unit": "%"})
+    ent._fake_last_state = LastState("41")
+    await ent.async_added_to_hass()
+    assert ent.state == "41"
+
+    # Fresh update arrives
+    coord._stale = False
+    coord.last_successful_update = datetime.now(timezone.utc)
+    coord.get_pid_value = lambda k: 55
+    ent._handle_coordinator_update()
+    assert ent.state == 55
+    attrs = ent.extra_state_attributes
+    assert attrs["wican_data_stale"] is False
+    assert isinstance(attrs["last_successful_update"], str)
+    assert ent.available is True

--- a/tests/test_setup_integration.py
+++ b/tests/test_setup_integration.py
@@ -1,0 +1,261 @@
+import sys
+import types
+import pytest
+import importlib.util
+import os
+
+
+def make_ha_stubs():
+    ha_pkg = types.ModuleType("homeassistant")
+
+    const_mod = types.ModuleType("homeassistant.const")
+    const_mod.CONF_IP_ADDRESS = "ip_address"
+    const_mod.CONF_SCAN_INTERVAL = "scan_interval"
+
+    class Platform:
+        BINARY_SENSOR = "binary_sensor"
+        SENSOR = "sensor"
+
+    const_mod.Platform = Platform
+
+    core_mod = types.ModuleType("homeassistant.core")
+    class HomeAssistant:
+        pass
+    def callback(fn):
+        return fn
+    core_mod.HomeAssistant = HomeAssistant
+    core_mod.callback = callback
+
+    exceptions_mod = types.ModuleType("homeassistant.exceptions")
+    class ConfigEntryNotReady(Exception):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args)
+    exceptions_mod.ConfigEntryNotReady = ConfigEntryNotReady
+
+    helpers_pkg = types.ModuleType("homeassistant.helpers")
+    helpers_update_coordinator_mod = types.ModuleType("homeassistant.helpers.update_coordinator")
+    class DataUpdateCoordinator:
+        def __init__(self, *a, **kw):
+            self.data = {}
+        async def async_config_entry_first_refresh(self):
+            if hasattr(self, "_async_update_data"):
+                self.data = await self._async_update_data()
+    class CoordinatorEntity:
+        def __init__(self, coordinator):
+            self.coordinator = coordinator
+        async def async_added_to_hass(self):
+            pass
+        def async_write_ha_state(self):
+            pass
+    helpers_update_coordinator_mod.DataUpdateCoordinator = DataUpdateCoordinator
+    helpers_update_coordinator_mod.CoordinatorEntity = CoordinatorEntity
+
+    helpers_storage_mod = types.ModuleType("homeassistant.helpers.storage")
+    class Store:
+        def __init__(self, hass, version: int, key: str):
+            self.hass = hass
+            self.version = version
+            self.key = key
+            self.data = None
+        async def async_load(self):
+            return self.data
+        async def async_save(self, data):
+            self.data = data
+    helpers_storage_mod.Store = Store
+
+    util_pkg = types.ModuleType("homeassistant.util")
+    dt_mod = types.ModuleType("homeassistant.util.dt")
+    from datetime import datetime, timezone
+    def utcnow():
+        return datetime.now(timezone.utc)
+    def parse_datetime(s: str):
+        try:
+            return datetime.fromisoformat(s.replace("Z", "+00:00"))
+        except Exception:
+            return None
+    dt_mod.utcnow = utcnow
+    dt_mod.parse_datetime = parse_datetime
+
+    config_entries_mod = types.ModuleType("homeassistant.config_entries")
+    class ConfigEntry:
+        pass
+    config_entries_mod.ConfigEntry = ConfigEntry
+
+    sys.modules["homeassistant"] = ha_pkg
+    sys.modules["homeassistant.const"] = const_mod
+    sys.modules["homeassistant.core"] = core_mod
+    sys.modules["homeassistant.exceptions"] = exceptions_mod
+    sys.modules["homeassistant.helpers"] = helpers_pkg
+    sys.modules["homeassistant.helpers.update_coordinator"] = helpers_update_coordinator_mod
+    sys.modules["homeassistant.helpers.storage"] = helpers_storage_mod
+    sys.modules["homeassistant.util"] = util_pkg
+    sys.modules["homeassistant.util.dt"] = dt_mod
+    sys.modules["homeassistant.config_entries"] = config_entries_mod
+
+
+def load_modules_with_fakes(wican_api):
+    repo_root = os.path.dirname(os.path.dirname(__file__))
+    # Ensure custom_components packages exist without importing package __init__
+    cc_pkg = sys.modules.setdefault("custom_components", types.ModuleType("custom_components"))
+    if not hasattr(cc_pkg, "__path__"):
+        cc_pkg.__path__ = [os.path.join(repo_root, "custom_components")]
+    wican_pkg = sys.modules.setdefault("custom_components.wican", types.ModuleType("custom_components.wican"))
+    wican_pkg.__path__ = [os.path.join(repo_root, "custom_components", "wican")]
+
+    # Provide fake wican API module
+    fake_wican_mod = types.ModuleType("custom_components.wican.wican")
+    class WiCan:
+        def __init__(self, ip):
+            self.ip = ip
+        async def check_status(self):
+            return await wican_api.check_status()
+        async def get_pid(self):
+            return await wican_api.get_pid()
+    fake_wican_mod.WiCan = WiCan
+    sys.modules["custom_components.wican.wican"] = fake_wican_mod
+
+    # Load coordinator first so that __init__ pulls the same module
+    name_coord = "custom_components.wican.coordinator"
+    file_coord = os.path.join(repo_root, "custom_components", "wican", "coordinator.py")
+    spec_c = importlib.util.spec_from_file_location(name_coord, file_coord)
+    mod_c = importlib.util.module_from_spec(spec_c)
+    sys.modules[name_coord] = mod_c
+    assert spec_c and spec_c.loader
+    spec_c.loader.exec_module(mod_c)  # type: ignore[attr-defined]
+
+    # Load integration __init__
+    name_init = "custom_components.wican.__init__"
+    file_init = os.path.join(repo_root, "custom_components", "wican", "__init__.py")
+    spec_i = importlib.util.spec_from_file_location(name_init, file_init)
+    mod_i = importlib.util.module_from_spec(spec_i)
+    sys.modules[name_init] = mod_i
+    assert spec_i and spec_i.loader
+    spec_i.loader.exec_module(mod_i)  # type: ignore[attr-defined]
+    return mod_i, mod_c
+
+
+class DummyEntry:
+    def __init__(self, ip: str, entry_id: str = "e1"):
+        self.entry_id = entry_id
+        self.data = {"ip_address": ip}
+        self.options = {}
+
+
+class FakeConfigEntries:
+    def __init__(self):
+        self.forwarded = None
+    async def async_forward_entry_setups(self, entry, platforms):
+        self.forwarded = platforms
+
+
+class FakeHass:
+    def __init__(self):
+        self.data = {}
+        self.config_entries = FakeConfigEntries()
+
+
+class APIGood:
+    async def check_status(self):
+        return {"device_id": "devS", "ecu_status": "online", "hw_version": "1", "sta_ip": "1.2.3.4", "fw_version": "1"}
+    async def get_pid(self):
+        return {"SOC": {"class": "none", "unit": "%", "value": 50}}
+
+
+class APIOffline:
+    async def check_status(self):
+        return False
+    async def get_pid(self):
+        return False
+
+
+@pytest.mark.asyncio
+async def test_fresh_install_online_succeeds_and_forwards_platforms():
+    make_ha_stubs()
+    hass = FakeHass()
+    entry = DummyEntry("1.2.3.4")
+    init_mod, coord_mod = load_modules_with_fakes(APIGood())
+
+    ok = await init_mod.async_setup_entry(hass, entry)
+    assert ok is True
+    assert hass.config_entries.forwarded == ["binary_sensor", "sensor"]
+    # Coordinator is stored
+    from custom_components.wican.const import DOMAIN
+    assert DOMAIN in hass.data and entry.entry_id in hass.data[DOMAIN]
+
+
+@pytest.mark.asyncio
+async def test_fresh_install_offline_raises_not_ready():
+    make_ha_stubs()
+    hass = FakeHass()
+    entry = DummyEntry("1.2.3.4")
+    init_mod, coord_mod = load_modules_with_fakes(APIOffline())
+    from homeassistant.exceptions import ConfigEntryNotReady
+    with pytest.raises(ConfigEntryNotReady):
+        await init_mod.async_setup_entry(hass, entry)
+
+
+@pytest.mark.asyncio
+async def test_restart_offline_with_snapshot_uses_snapshot_and_forwards():
+    make_ha_stubs()
+    hass = FakeHass()
+    entry = DummyEntry("1.2.3.4")
+    init_mod, coord_mod = load_modules_with_fakes(APIOffline())
+    # Preload snapshot by patching Store
+    store = sys.modules["homeassistant.helpers.storage"].Store
+    # Create a coordinator instance to access the store key
+    # But easier: monkeypatch the Store class to return snapshot on first load
+    class StoreWithSnapshot(store):
+        async def async_load(self):
+            return {
+                "device_id": "devSnap",
+                "status": {"device_id": "devSnap", "ecu_status": "offline", "hw_version": "1", "sta_ip": "1.2.3.5", "fw_version": "1"},
+                "pid": {"SOC": {"class": "none", "unit": "%", "value": 33}},
+                "timestamp": "2024-01-01T00:00:00+00:00",
+            }
+    sys.modules["homeassistant.helpers.storage"].Store = StoreWithSnapshot
+    # Ensure coordinator uses the patched Store symbol
+    coord_mod.Store = StoreWithSnapshot
+
+    ok = await init_mod.async_setup_entry(hass, entry)
+    assert ok is True
+    assert hass.config_entries.forwarded == ["binary_sensor", "sensor"]
+    # Coordinator should be marked stale after refresh uses memory/snapshot
+    from custom_components.wican.const import DOMAIN
+    coord = hass.data[DOMAIN][entry.entry_id]
+    assert coord.stale() is True
+
+
+@pytest.mark.asyncio
+async def test_device_recovers_after_offline_setup():
+    make_ha_stubs()
+    hass = FakeHass()
+    entry = DummyEntry("1.2.3.4")
+    # Start offline with snapshot
+    init_mod, coord_mod = load_modules_with_fakes(APIOffline())
+    store = sys.modules["homeassistant.helpers.storage"].Store
+    class StoreWithSnapshot(store):
+        async def async_load(self):
+            return {
+                "device_id": "devSnap",
+                "status": {"device_id": "devSnap", "ecu_status": "offline", "hw_version": "1", "sta_ip": "1.2.3.5", "fw_version": "1"},
+                "pid": {"SOC": {"class": "none", "unit": "%", "value": 33}},
+                "timestamp": "2024-01-01T00:00:00+00:00",
+            }
+    sys.modules["homeassistant.helpers.storage"].Store = StoreWithSnapshot
+    coord_mod.Store = StoreWithSnapshot
+
+    ok = await init_mod.async_setup_entry(hass, entry)
+    assert ok is True
+    from custom_components.wican.const import DOMAIN
+    coord = hass.data[DOMAIN][entry.entry_id]
+    assert coord.stale() is True
+
+    # Now swap API to online and refresh
+    init_mod, _ = load_modules_with_fakes(APIGood())
+    api_good = init_mod.WiCan  # not used directly here
+    # Call coordinator.get_data with a fake api bound to coordinator
+    coord.api.check_status = lambda: APIGood().check_status()
+    coord.api.get_pid = lambda: APIGood().get_pid()
+    data = await coord.get_data()
+    assert coord.stale() is False
+    assert isinstance(coord.last_successful_update, object)

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -1,0 +1,293 @@
+import sys
+import types
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+import importlib.util
+import os
+
+
+# Create minimal stubs for Home Assistant modules to avoid heavy dependencies.
+ha_pkg = types.ModuleType("homeassistant")
+
+const_mod = types.ModuleType("homeassistant.const")
+const_mod.CONF_SCAN_INTERVAL = "scan_interval"
+const_mod.CONF_IP_ADDRESS = "ip_address"
+
+
+class Platform:
+    BINARY_SENSOR = "binary_sensor"
+    SENSOR = "sensor"
+
+
+const_mod.Platform = Platform
+
+core_mod = types.ModuleType("homeassistant.core")
+
+
+class HomeAssistant:  # simple stub
+    pass
+
+
+def callback(func):
+    return func
+
+
+core_mod.HomeAssistant = HomeAssistant
+core_mod.callback = callback
+
+exceptions_mod = types.ModuleType("homeassistant.exceptions")
+
+
+class ConfigEntryNotReady(Exception):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args)
+
+
+exceptions_mod.ConfigEntryNotReady = ConfigEntryNotReady
+
+helpers_pkg = types.ModuleType("homeassistant.helpers")
+helpers_update_coordinator_mod = types.ModuleType(
+    "homeassistant.helpers.update_coordinator"
+)
+
+
+class DataUpdateCoordinator:  # minimal stub for inheritance only
+    def __init__(self, hass, logger, name: 'str | None' = None, update_interval=None):
+        self.hass = hass
+        self.logger = logger
+        self.name = name
+        self.update_interval = update_interval
+        self.data: dict[str, Any] = {}
+
+
+helpers_update_coordinator_mod.DataUpdateCoordinator = DataUpdateCoordinator
+
+helpers_storage_mod = types.ModuleType("homeassistant.helpers.storage")
+
+
+class Store:  # will be monkeypatched in tests
+    def __init__(self, hass, version: int, key: str) -> None:
+        self.hass = hass
+        self.version = version
+        self.key = key
+
+    async def async_load(self):
+        return None
+
+    async def async_save(self, data):
+        return None
+
+
+helpers_storage_mod.Store = Store
+
+util_pkg = types.ModuleType("homeassistant.util")
+dt_mod = types.ModuleType("homeassistant.util.dt")
+
+
+def utcnow():
+    return datetime.now(timezone.utc)
+
+
+def parse_datetime(value: str):
+    try:
+        # Accept both ISO formats with Z and with offset
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except Exception:
+        return None
+
+
+dt_mod.utcnow = utcnow
+dt_mod.parse_datetime = parse_datetime
+
+# Wire up the package structure in sys.modules
+sys.modules["homeassistant"] = ha_pkg
+sys.modules["homeassistant.const"] = const_mod
+sys.modules["homeassistant.core"] = core_mod
+sys.modules["homeassistant.exceptions"] = exceptions_mod
+config_entries_mod = types.ModuleType("homeassistant.config_entries")
+
+
+class ConfigEntry:
+    pass
+
+
+config_entries_mod.ConfigEntry = ConfigEntry
+sys.modules["homeassistant.config_entries"] = config_entries_mod
+sys.modules["homeassistant.helpers"] = helpers_pkg
+sys.modules["homeassistant.helpers.update_coordinator"] = (
+    helpers_update_coordinator_mod
+)
+sys.modules["homeassistant.helpers.storage"] = helpers_storage_mod
+sys.modules["homeassistant.util"] = util_pkg
+sys.modules["homeassistant.util.dt"] = dt_mod
+
+from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
+
+
+def load_coordinator_module():
+    """Dynamically load the coordinator module without importing package __init__."""
+    name = "custom_components.wican.coordinator"
+    if name in sys.modules:
+        return sys.modules[name]
+
+    # Ensure package stubs exist with proper __path__ to real files
+    repo_root = os.path.dirname(os.path.dirname(__file__))
+    cc_pkg = sys.modules.setdefault("custom_components", types.ModuleType("custom_components"))
+    if not hasattr(cc_pkg, "__path__"):
+        cc_pkg.__path__ = [os.path.join(repo_root, "custom_components")]
+    wican_pkg = sys.modules.setdefault("custom_components.wican", types.ModuleType("custom_components.wican"))
+    wican_pkg.__path__ = [os.path.join(repo_root, "custom_components", "wican")]
+
+    file_path = os.path.join(repo_root, "custom_components", "wican", "coordinator.py")
+    spec = importlib.util.spec_from_file_location(name, file_path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    assert spec and spec.loader
+    spec.loader.exec_module(mod)  # type: ignore[attr-defined]
+    return mod
+
+
+class FakeStore:
+    """In-memory fake Store for testing snapshot persistence."""
+
+    def __init__(self, hass: HomeAssistant, version: int, key: str) -> None:
+        self.hass = hass
+        self.version = version
+        self.key = key
+        self.data: Any = None
+        self.save_calls = 0
+        self.load_calls = 0
+        self.load_return: Any = None
+        self.load_exception: Any = None
+
+    async def async_load(self):
+        self.load_calls += 1
+        if self.load_exception:
+            raise self.load_exception
+        return self.load_return
+
+    async def async_save(self, data):
+        self.save_calls += 1
+        self.data = data
+
+
+class DummyEntry:
+    def __init__(self, entry_id: str = "test_entry") -> None:
+        self.entry_id = entry_id
+        self.data = {}
+        self.options = {}
+
+
+class FakeAPI:
+    def __init__(self, status, pid, ip: str = "1.2.3.4") -> None:
+        self._status = status
+        self._pid = pid
+        self.ip = ip
+
+    async def check_status(self):
+        return self._status
+
+    async def get_pid(self):
+        return self._pid
+
+
+@pytest.fixture
+def hass():
+    return HomeAssistant()
+
+
+@pytest.mark.asyncio
+async def test_persist_snapshot_on_successful_refresh(hass: HomeAssistant, monkeypatch):
+    coordinator_mod = load_coordinator_module()
+    monkeypatch.setattr(coordinator_mod, "Store", FakeStore, raising=True)
+    status = {
+        "device_id": "dev123",
+        "ecu_status": "online",
+        "hw_version": "1.0",
+        "sta_ip": "1.2.3.4",
+        "fw_version": "0.0.1",
+    }
+    pid = {"SOC_BMS": {"class": "battery", "unit": "%", "value": 42}}
+
+    WiCanCoordinator = getattr(coordinator_mod, "WiCanCoordinator")
+
+    coordinator = WiCanCoordinator(hass, DummyEntry(), FakeAPI(status, pid))
+
+    data = await coordinator.get_data()
+
+    # Persisted once with expected content
+    store: FakeStore = coordinator._store  # type: ignore[attr-defined]
+    assert store.save_calls == 1
+    assert isinstance(store.data, dict)
+    assert store.data["device_id"] == "dev123"
+    assert store.data["status"] == status
+    assert store.data["pid"] == pid
+    # Timestamp is ISO8601
+    assert isinstance(store.data["timestamp"], str)
+    assert dt_util.parse_datetime(store.data["timestamp"]) is not None
+    # Returned data mirrors live
+    assert data["status"] == status
+    assert data["pid"] == pid
+
+
+@pytest.mark.asyncio
+async def test_offline_uses_snapshot(hass: HomeAssistant, monkeypatch):
+    coordinator_mod = load_coordinator_module()
+    monkeypatch.setattr(coordinator_mod, "Store", FakeStore, raising=True)
+    snapshot = {
+        "device_id": "dev999",
+        "status": {"device_id": "dev999", "ecu_status": "offline"},
+        "pid": {"X": {"class": "none", "unit": "none", "value": 0}},
+        "timestamp": dt_util.utcnow().isoformat(),
+    }
+
+    WiCanCoordinator = getattr(coordinator_mod, "WiCanCoordinator")
+
+    coordinator = WiCanCoordinator(hass, DummyEntry(), FakeAPI(False, False))
+    # Preload the store with a snapshot to be returned
+    store: FakeStore = coordinator._store  # type: ignore[attr-defined]
+    store.load_return = snapshot
+
+    data = await coordinator.get_data()
+
+    assert data["status"] == snapshot["status"]
+    assert data["pid"] == snapshot["pid"]
+
+
+@pytest.mark.asyncio
+async def test_corrupted_snapshot_logs_and_fallback(hass: HomeAssistant, monkeypatch, caplog):
+    coordinator_mod = load_coordinator_module()
+    monkeypatch.setattr(coordinator_mod, "Store", FakeStore, raising=True)
+    WiCanCoordinator = getattr(coordinator_mod, "WiCanCoordinator")
+
+    coordinator = WiCanCoordinator(hass, DummyEntry(), FakeAPI(False, False))
+    store: FakeStore = coordinator._store  # type: ignore[attr-defined]
+    store.load_exception = ValueError("corrupt")
+
+    from homeassistant.exceptions import ConfigEntryNotReady
+
+    with caplog.at_level("WARNING"):
+        with pytest.raises(ConfigEntryNotReady):
+            await coordinator.get_data()
+    assert any("Failed to load WiCAN snapshot" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_debounced_writes(hass: HomeAssistant, monkeypatch):
+    coordinator_mod = load_coordinator_module()
+    monkeypatch.setattr(coordinator_mod, "Store", FakeStore, raising=True)
+    status = {"device_id": "debounce", "ecu_status": "online"}
+    pid = {"Y": {"class": "none", "unit": "none", "value": 1}}
+
+    WiCanCoordinator = getattr(coordinator_mod, "WiCanCoordinator")
+
+    coordinator = WiCanCoordinator(hass, DummyEntry(), FakeAPI(status, pid))
+    # Speed up the test by keeping default debounce interval and calling twice quickly
+    await coordinator.get_data()
+    await coordinator.get_data()
+
+    store: FakeStore = coordinator._store  # type: ignore[attr-defined]
+    assert store.save_calls == 1

--- a/tests/test_stale.py
+++ b/tests/test_stale.py
@@ -1,0 +1,278 @@
+import sys
+import types
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+import importlib.util
+import os
+
+
+# Minimal HA stubs (shared with previous tests but defined locally for isolation)
+ha_pkg = types.ModuleType("homeassistant")
+
+const_mod = types.ModuleType("homeassistant.const")
+const_mod.CONF_SCAN_INTERVAL = "scan_interval"
+const_mod.CONF_IP_ADDRESS = "ip_address"
+
+
+class Platform:
+    BINARY_SENSOR = "binary_sensor"
+    SENSOR = "sensor"
+
+
+const_mod.Platform = Platform
+
+core_mod = types.ModuleType("homeassistant.core")
+
+
+class HomeAssistant:  # simple stub
+    pass
+
+
+def callback(func):
+    return func
+
+
+core_mod.HomeAssistant = HomeAssistant
+core_mod.callback = callback
+
+exceptions_mod = types.ModuleType("homeassistant.exceptions")
+
+
+class ConfigEntryNotReady(Exception):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args)
+
+
+exceptions_mod.ConfigEntryNotReady = ConfigEntryNotReady
+
+helpers_pkg = types.ModuleType("homeassistant.helpers")
+helpers_update_coordinator_mod = types.ModuleType(
+    "homeassistant.helpers.update_coordinator"
+)
+
+
+class DataUpdateCoordinator:  # minimal stub for inheritance only
+    def __init__(self, hass, logger, name: 'str | None' = None, update_interval=None):
+        self.hass = hass
+        self.logger = logger
+        self.name = name
+        self.update_interval = update_interval
+        self.data: dict[str, Any] = {}
+
+
+helpers_update_coordinator_mod.DataUpdateCoordinator = DataUpdateCoordinator
+
+helpers_storage_mod = types.ModuleType("homeassistant.helpers.storage")
+
+
+class Store:  # will be monkeypatched in tests
+    def __init__(self, hass, version: int, key: str) -> None:
+        self.hass = hass
+        self.version = version
+        self.key = key
+
+    async def async_load(self):
+        return None
+
+    async def async_save(self, data):
+        return None
+
+
+helpers_storage_mod.Store = Store
+
+util_pkg = types.ModuleType("homeassistant.util")
+dt_mod = types.ModuleType("homeassistant.util.dt")
+
+
+def utcnow():
+    return datetime.now(timezone.utc)
+
+
+def parse_datetime(value: str):
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except Exception:
+        return None
+
+
+dt_mod.utcnow = utcnow
+dt_mod.parse_datetime = parse_datetime
+
+# Wire up the package structure in sys.modules
+sys.modules["homeassistant"] = ha_pkg
+sys.modules["homeassistant.const"] = const_mod
+sys.modules["homeassistant.core"] = core_mod
+sys.modules["homeassistant.exceptions"] = exceptions_mod
+config_entries_mod = types.ModuleType("homeassistant.config_entries")
+
+
+class ConfigEntry:
+    pass
+
+
+config_entries_mod.ConfigEntry = ConfigEntry
+sys.modules["homeassistant.config_entries"] = config_entries_mod
+sys.modules["homeassistant.helpers"] = helpers_pkg
+sys.modules["homeassistant.helpers.update_coordinator"] = (
+    helpers_update_coordinator_mod
+)
+sys.modules["homeassistant.helpers.storage"] = helpers_storage_mod
+sys.modules["homeassistant.util"] = util_pkg
+sys.modules["homeassistant.util.dt"] = dt_mod
+
+
+def load_coordinator_module():
+    name = "custom_components.wican.coordinator"
+    if name in sys.modules:
+        return sys.modules[name]
+
+    repo_root = os.path.dirname(os.path.dirname(__file__))
+    cc_pkg = sys.modules.setdefault("custom_components", types.ModuleType("custom_components"))
+    if not hasattr(cc_pkg, "__path__"):
+        cc_pkg.__path__ = [os.path.join(repo_root, "custom_components")]
+    wican_pkg = sys.modules.setdefault("custom_components.wican", types.ModuleType("custom_components.wican"))
+    wican_pkg.__path__ = [os.path.join(repo_root, "custom_components", "wican")]
+
+    file_path = os.path.join(repo_root, "custom_components", "wican", "coordinator.py")
+    spec = importlib.util.spec_from_file_location(name, file_path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    assert spec and spec.loader
+    spec.loader.exec_module(mod)  # type: ignore[attr-defined]
+    return mod
+
+
+class FakeStore:
+    def __init__(self, hass: HomeAssistant, version: int, key: str) -> None:
+        self.hass = hass
+        self.version = version
+        self.key = key
+        self.data: Any = None
+        self.load_return: Any = None
+        self.load_exception: Any = None
+        self.save_calls = 0
+
+    async def async_load(self):
+        if self.load_exception:
+            raise self.load_exception
+        return self.load_return
+
+    async def async_save(self, data):
+        self.save_calls += 1
+        self.data = data
+
+
+class DummyEntry:
+    def __init__(self, entry_id: str = "test_entry") -> None:
+        self.entry_id = entry_id
+        self.data = {}
+        self.options = {}
+
+
+class FakeAPI:
+    def __init__(self, status, pid, ip: str = "1.2.3.4") -> None:
+        self._status = status
+        self._pid = pid
+        self.ip = ip
+
+    async def check_status(self):
+        return self._status
+
+    async def get_pid(self):
+        return self._pid
+
+
+@pytest.fixture
+def hass():
+    return HomeAssistant()
+
+
+@pytest.mark.asyncio
+async def test_memory_data_offline_sets_stale(hass, monkeypatch):
+    coordinator_mod = load_coordinator_module()
+    monkeypatch.setattr(coordinator_mod, "Store", FakeStore, raising=True)
+    WiCanCoordinator = getattr(coordinator_mod, "WiCanCoordinator")
+
+    # First success
+    status = {"device_id": "dev123", "ecu_status": "online"}
+    pid = {"X": {"class": "none", "unit": "none", "value": 1}}
+    api = FakeAPI(status, pid)
+    coordinator = WiCanCoordinator(hass, DummyEntry(), api)
+    coordinator.data = await coordinator.get_data()
+    assert coordinator.stale() is False
+    assert coordinator.last_successful_update is not None
+
+    # Now device goes offline
+    api._status = False
+    data2 = await coordinator.get_data()
+    assert data2 == coordinator.data  # should serve memory
+    assert coordinator.stale() is True
+
+
+@pytest.mark.asyncio
+async def test_snapshot_used_when_no_memory_offline(hass, monkeypatch):
+    coordinator_mod = load_coordinator_module()
+    monkeypatch.setattr(coordinator_mod, "Store", FakeStore, raising=True)
+    WiCanCoordinator = getattr(coordinator_mod, "WiCanCoordinator")
+
+    snapshot = {
+        "device_id": "dev999",
+        "status": {"device_id": "dev999", "ecu_status": "offline"},
+        "pid": {"Y": {"class": "none", "unit": "none", "value": 0}},
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+    api = FakeAPI(False, False)
+    coordinator = WiCanCoordinator(hass, DummyEntry(), api)
+    # Inject snapshot before first refresh
+    store: FakeStore = coordinator._store  # type: ignore[attr-defined]
+    store.load_return = snapshot
+
+    data = await coordinator.get_data()
+    assert data["status"] == snapshot["status"]
+    assert coordinator.stale() is True
+    assert coordinator.last_successful_update is None
+
+
+@pytest.mark.asyncio
+async def test_first_run_offline_no_snapshot_raises(hass, monkeypatch):
+    coordinator_mod = load_coordinator_module()
+    monkeypatch.setattr(coordinator_mod, "Store", FakeStore, raising=True)
+    WiCanCoordinator = getattr(coordinator_mod, "WiCanCoordinator")
+
+    api = FakeAPI(False, False)
+    coordinator = WiCanCoordinator(hass, DummyEntry(), api)
+
+    from homeassistant.exceptions import ConfigEntryNotReady
+    with pytest.raises(ConfigEntryNotReady):
+        await coordinator.get_data()
+
+
+@pytest.mark.asyncio
+async def test_recovery_clears_stale_and_updates_timestamp(hass, monkeypatch):
+    coordinator_mod = load_coordinator_module()
+    monkeypatch.setattr(coordinator_mod, "Store", FakeStore, raising=True)
+    WiCanCoordinator = getattr(coordinator_mod, "WiCanCoordinator")
+
+    # Start with snapshot path
+    snapshot = {
+        "device_id": "dev999",
+        "status": {"device_id": "dev999", "ecu_status": "offline"},
+        "pid": {"Z": {"class": "none", "unit": "none", "value": 5}},
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+    api = FakeAPI(False, False)
+    coordinator = WiCanCoordinator(hass, DummyEntry(), api)
+    store: FakeStore = coordinator._store  # type: ignore[attr-defined]
+    store.load_return = snapshot
+    await coordinator.get_data()
+    assert coordinator.stale() is True
+    assert coordinator.last_successful_update is None
+
+    # Device becomes reachable
+    api._status = {"device_id": "dev999", "ecu_status": "online", "hw_version": "1", "sta_ip": "1.2.3.4", "fw_version": "1"}
+    api._pid = {"Z": {"class": "none", "unit": "none", "value": 42}}
+    await coordinator.get_data()
+    assert coordinator.stale() is False
+    assert coordinator.last_successful_update is not None


### PR DESCRIPTION
fixes #32 

I would love other people to try this out. It seems to work for me, but I've not gone one-by-one through every data field.

# feat: Offline‑tolerant WiCAN — snapshot restore, staleness metadata, robust API, and tests

## Summary
This PR makes the WiCAN Home Assistant integration resilient to offline devices. It persists a minimal snapshot of the last‑known data, restores state on startup, exposes freshness/staleness metadata, and adds timeouts/error handling to the API client. A new test workflow validates these behaviours end‑to‑end.

## Key Changes
- Coordinator
  - Persist last‑known snapshot (`device_id`, `status`, `pid`, `timestamp`) via HA `Store` (debounced writes, 30s).
  - `async_preload_snapshot()` seeds `coordinator.data` during setup if a snapshot exists.
  - Offline‑tolerant refresh:
    - Success: updates data, sets `_stale = False`, records `last_successful_update`.
    - Failure: return in‑memory data when available; else load snapshot; else (first run only) raise `ConfigEntryNotReady`.
  - Track `stale()` flag and `last_successful_update` timestamp.

- Entities
  - Inherit `RestoreEntity` alongside `CoordinatorEntity`.
  - On `async_added_to_hass()`, restore last HA state when coordinator is stale and no live value is present.
  - Add freshness attributes to `extra_state_attributes`:
    - `wican_data_stale: bool`
    - `last_successful_update: ISO8601 | null`
  - Availability: remain available when serving stale data (so entities don’t disappear).

- API Client
  - Add `aiohttp.ClientTimeout(total=5s)` to all calls.
  - Catch `aiohttp.ClientError`, `asyncio.TimeoutError`, `OSError`; log at debug and return sentinel `False` so coordinator can fallback.
  - Replace `match` with `if/else` for wider Python compatibility.

- Integration Setup
  - `async_setup_entry()` preloads snapshot before the first refresh, then awaits `async_config_entry_first_refresh()`.
  - Forward platforms only when coordinator has usable data (live or snapshot). First‑run offline without snapshot will retry via `ConfigEntryNotReady`.

- Documentation
  - README: “Offline, Restore, and Freshness” section; network robustness; test quickstart.

- CI
  - New GitHub Actions workflow `.github/workflows/tests.yaml` running `pytest` as a separate check from hassfest.

## Tests
Added comprehensive, self‑contained tests (with lightweight HA/aiohttp stubs):
- Snapshot persistence (`tests/test_snapshot.py`)
  - Persist after successful refresh; validate schema and ISO timestamp
  - Load snapshot when offline; corruption handling; debounced writes
- Staleness (`tests/test_stale.py`)
  - In‑memory stale path; snapshot fallback path; first‑run without snapshot raises NotReady; recovery clears stale and updates timestamp
- Entity restore (`tests/test_entity_restore.py`)
  - RestoreEntity on startup while stale; freshness attributes; availability; update to fresh data
- API robustness (`tests/test_api_timeouts.py`)
  - Timeouts/exceptions return `False`; coordinator goes stale on timeout
- Integration setup (`tests/test_setup_integration.py`)
  - Fresh install online (succeeds, forwards platforms)
  - Fresh install offline (NotReady)
  - Restart offline with snapshot (entities present, stale=true)
  - Device recovers to fresh after being offline

Result: full suite passing locally (17 tests).

## Backwards Compatibility & Risk
- No breaking changes to unique IDs or entity naming.
- Entities gain extra attributes only (safe for consumers).
- Storage via HA `Store` under entry‑scoped key; no manual migration required.
- Logging for payloads remains at debug; warnings used sparingly.


## Live Sample

This is a screenshot from my van, the WICAN has been off for a few hours. 

<img width="851" height="560" alt="image" src="https://github.com/user-attachments/assets/67ca64e1-8bf4-4c3f-802a-f3a96e5dc295" />
