### PR TITLE
Fix webhook URL fallback handling

### DIFF
--- a/custom_components/wican/__init__.py
+++ b/custom_components/wican/__init__.py
@@ -17,7 +17,6 @@ from homeassistant.const import CONF_WEBHOOK_ID, EVENT_HOMEASSISTANT_STARTED, Pl
 from homeassistant.exceptions import ConfigEntryError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.dispatcher import async_dispatcher_send
-from homeassistant.helpers.network import get_url
 import voluptuous as vol
 from yarl import URL
 
@@ -33,6 +32,7 @@ from .const import (
 from .coordinator import WiCANDataUpdateCoordinator
 from .exceptions import WiCANWebhookError
 from .github_releases import GitHubReleasesCoordinator
+from .helpers import resolve_webhook_url
 from .models import WiCANRuntimeData
 from .param_loader import async_update_params_from_github
 
@@ -378,9 +378,11 @@ async def _async_register_webhook_on_device(  # noqa: C901, PLR0912, PLR0915
             entry.runtime_data.device_host = derived_host
 
     try:
-        base_url: str = get_url(hass)
-        webhook_path = webhook.async_generate_url(hass, entry.runtime_data.webhook_id)
-        webhook_url = webhook_path if webhook_path.startswith("http") else str(URL(base_url) / webhook_path.lstrip("/"))
+        webhook_url = resolve_webhook_url(
+            hass,
+            entry.runtime_data.webhook_id,
+            fallback_url=entry.data.get("webhook_url"),
+        )
     except Exception as err:
         _LOGGER.warning("Cannot generate webhook URL for %s: %s", entry.entry_id, err)
         return False

--- a/custom_components/wican/__init__.py
+++ b/custom_components/wican/__init__.py
@@ -377,6 +377,28 @@ async def _async_register_webhook_on_device(  # noqa: C901, PLR0912, PLR0915
             host = derived_host
             entry.runtime_data.device_host = derived_host
 
+    # Lightweight migration/backfill for older entries: if webhook_url was not
+    # persisted when this entry was created, try to compute and store it now so
+    # that future calls can rely on the fallback.
+    if "webhook_url" not in entry.data:
+        try:
+            resolved_url = resolve_webhook_url(
+                hass,
+                entry.runtime_data.webhook_id,
+            )
+        except Exception:
+            resolved_url = None
+        else:
+            if resolved_url:
+                # Update the config entry data with the resolved webhook_url.
+                await hass.config_entries.async_update_entry(
+                    entry,
+                    data={**entry.data, "webhook_url": resolved_url},
+                )
+                _LOGGER.debug(
+                    "Backfilled webhook_url for entry %s", entry.entry_id
+                )
+
     try:
         webhook_url = resolve_webhook_url(
             hass,

--- a/custom_components/wican/attributes.py
+++ b/custom_components/wican/attributes.py
@@ -33,6 +33,7 @@ SENSOR_DESCRIPTIONS: tuple[WiCANSensorEntityDescription, ...] = (
         icon="mdi:car-battery",
         device_class=SensorDeviceClass.VOLTAGE,
         native_unit_of_measurement="V",
+        suggested_display_precision=1,
         extra_attributes=[
             "batt_alert",
             "batt_alert_volt",

--- a/custom_components/wican/config_flow.py
+++ b/custom_components/wican/config_flow.py
@@ -7,10 +7,9 @@ from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
 from homeassistant import config_entries
-from homeassistant.components import onboarding, webhook
+from homeassistant.components import onboarding
 from homeassistant.const import CONF_HOST, CONF_WEBHOOK_ID
 from homeassistant.core import callback
-from homeassistant.helpers.network import get_url
 import voluptuous as vol
 from yarl import URL
 
@@ -21,6 +20,7 @@ from .const import (
     MAX_POST_INTERVAL,
     MIN_POST_INTERVAL,
 )
+from .helpers import resolve_webhook_url
 
 if TYPE_CHECKING:
     from ipaddress import IPv4Address, IPv6Address
@@ -51,12 +51,28 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             host = user_input.get(CONF_HOST)
             title = host or mdns or "WiCAN"
             webhook_id = uuid4().hex
-            entry_data = {CONF_WEBHOOK_ID: webhook_id}
+            webhook_url = resolve_webhook_url(
+                self.hass,
+                webhook_id,
+                require_current_request=True,
+            )
+            entry_data = {
+                CONF_WEBHOOK_ID: webhook_id,
+                "webhook_url": webhook_url,
+            }
             if mdns:
                 entry_data["mdns"] = _format_http_url(mdns, None) or mdns
             if host:
                 entry_data["host"] = _format_http_url(host, None) or host
-            return self.async_create_entry(title=title, data=entry_data)
+
+            return self.async_create_entry(
+                title=title,
+                data=entry_data,
+                description_placeholders={
+                    "webhook_url": webhook_url,
+                    "docs_url": "https://github.com/meatpiHQ/wican-fw",
+                },
+            )
 
         data_schema = vol.Schema(
             {
@@ -130,17 +146,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # Auto-add during onboarding for seamless setup
         if user_input is not None or not onboarding.async_is_onboarded(self.hass):
             webhook_id = uuid4().hex
-
-            # Generate webhook URL for display
-            try:
-                base_url = get_url(self.hass)
-                webhook_path = webhook.async_generate_url(self.hass, webhook_id)
-                if webhook_path.startswith("http"):
-                    webhook_url = webhook_path
-                else:
-                    webhook_url = str(URL(base_url) / webhook_path.lstrip("/"))
-            except Exception:
-                webhook_url = f"<webhook_id: {webhook_id}>"
+            webhook_url = resolve_webhook_url(
+                self.hass,
+                webhook_id,
+                require_current_request=True,
+            )
 
             return self.async_create_entry(
                 title=self.discovered_name or "WiCAN",
@@ -150,6 +160,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         "mdns": self.discovered_mdns,
                         CONF_HOST: self.discovered_host,
                         CONF_WEBHOOK_ID: webhook_id,
+                        "webhook_url": webhook_url,
                         "mac": self.discovered_mac,
                         "device_id": self.discovered_device_id,
                     }.items()

--- a/custom_components/wican/coordinator.py
+++ b/custom_components/wican/coordinator.py
@@ -147,15 +147,21 @@ class WiCANDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if raw_value is None:
             return None
 
-        # Battery voltage: strip "V" suffix and convert to float
-        if key == "batt_voltage" and isinstance(raw_value, str) and raw_value.endswith("V"):
-            try:
-                return float(raw_value[:-1])
-            except ValueError:
-                _LOGGER.warning(
-                    "Failed to parse battery voltage: %s", raw_value,
-                )
-                return raw_value
+        # Battery voltage: strip "V" / " V" suffix (any case) and convert to float
+        # Handles firmware variants: "12.5V", "12.5 V", "12.5v", " 12.5 V "
+        if key == "batt_voltage" and isinstance(raw_value, str):
+            _LOGGER.debug("Raw batt_voltage from device: %r", raw_value)
+            stripped = raw_value.strip()
+            if stripped.upper().endswith("V"):
+                numeric_part = stripped[:-1].strip()
+                try:
+                    return float(numeric_part)
+                except ValueError:
+                    _LOGGER.warning(
+                        "Failed to parse battery voltage: %r (numeric part: %r)",
+                        raw_value, numeric_part,
+                    )
+                    return raw_value
 
         # Generic numeric string conversion
         if isinstance(raw_value, str):

--- a/custom_components/wican/data/params.json
+++ b/custom_components/wican/data/params.json
@@ -131,6 +131,14 @@
       "class": "none"
     }
   },
+  "FUEL_L": {
+    "description": "Fuel Level (Liters)",
+    "settings": {
+      "unit": "L",
+      "class": "none",
+      "min": "0"
+    }
+  },
   "FUEL_PRESSURE": {
     "description": "Fuel Pressure",
     "settings": {
@@ -362,6 +370,13 @@
     "settings": {
       "unit": "kwh",
       "class": "battery"
+    }
+  },
+  "LV_A": {
+    "description": "12v Battery Current",
+    "settings": {
+      "unit": "A",
+      "class": "current"
     }
   },
   "LV_V": {

--- a/custom_components/wican/helpers.py
+++ b/custom_components/wican/helpers.py
@@ -6,7 +6,10 @@ from functools import wraps
 import logging
 from typing import TYPE_CHECKING, Any, Concatenate, TypeVar
 
+from homeassistant.components import webhook
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.network import NoURLAvailableError, get_url
+from yarl import URL
 
 from .const import DOMAIN
 from .exceptions import WiCANConnectionError, WiCANError
@@ -14,12 +17,59 @@ from .exceptions import WiCANConnectionError, WiCANError
 if TYPE_CHECKING:
     from collections.abc import Callable, Coroutine
 
+    from homeassistant.core import HomeAssistant
+
     from .entity import WiCANEntity
 
 _LOGGER = logging.getLogger(__name__)
 
 _WiCANEntityT = TypeVar("_WiCANEntityT", bound="WiCANEntity")
 _P = TypeVar("_P")
+
+
+def build_webhook_url(base_url: str, webhook_id: str) -> str:
+    """Build an absolute webhook URL from a base URL and webhook id."""
+    return str(URL(base_url) / webhook.async_generate_path(webhook_id).lstrip("/"))
+
+
+def resolve_webhook_url(
+    hass: HomeAssistant,
+    webhook_id: str,
+    *,
+    fallback_url: str | None = None,
+    require_current_request: bool = False,
+) -> str:
+    """Resolve the best available absolute webhook URL.
+
+    Prefer Home Assistant's normal URL resolution with IPs allowed and internal
+    addresses favored, then optionally fall back to the active request host.
+    Finally, reuse a previously stored webhook URL if one exists.
+    """
+    try:
+        return webhook.async_generate_url(
+            hass,
+            webhook_id,
+            allow_ip=True,
+            prefer_external=False,
+        )
+    except NoURLAvailableError as original_error:
+        if require_current_request:
+            try:
+                current_request_base = get_url(
+                    hass,
+                    require_current_request=True,
+                    allow_cloud=False,
+                    allow_ip=True,
+                    prefer_external=False,
+                )
+                return build_webhook_url(current_request_base, webhook_id)
+            except NoURLAvailableError:
+                pass
+
+        if fallback_url:
+            return fallback_url
+
+        raise original_error
 
 
 def wican_exception_handler[WiCANEntityT: "WiCANEntity"](

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -9,6 +9,7 @@ import pytest
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 from homeassistant.const import CONF_NAME, CONF_WEBHOOK_ID
 
 from custom_components.wican.const import DOMAIN
@@ -38,6 +39,8 @@ async def test_user_flow_success(
     assert result2["title"] == "http://wican_test.local:80"
     assert result2["data"]["mdns"] == "http://wican_test.local:80"
     assert CONF_WEBHOOK_ID in result2["data"]
+    assert result2["data"]["webhook_url"].endswith(result2["data"][CONF_WEBHOOK_ID])
+    assert result2["description_placeholders"]["webhook_url"] == result2["data"]["webhook_url"]
 
 
 async def test_user_flow_cannot_connect(
@@ -58,6 +61,7 @@ async def test_user_flow_cannot_connect(
     )
 
     assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["description_placeholders"]["webhook_url"] == result2["data"]["webhook_url"]
 
 
 async def test_user_flow_adds_http_scheme(
@@ -84,8 +88,6 @@ async def test_zeroconf_flow_success(
     mock_aiohttp_session,
 ) -> None:
     """Test zeroconf discovery flow with confirmation and MAC address."""
-    from homeassistant.components.zeroconf import ZeroconfServiceInfo
-
     discovery_info = ZeroconfServiceInfo(
         ip_address="192.168.1.100",
         ip_addresses=["192.168.1.100"],
@@ -136,8 +138,6 @@ async def test_zeroconf_flow_not_wican(
     hass: HomeAssistant,
 ) -> None:
     """Test zeroconf discovery ignores non-WiCAN devices."""
-    from homeassistant.components.zeroconf import ZeroconfServiceInfo
-
     discovery_info = ZeroconfServiceInfo(
         ip_address="192.168.1.200",
         ip_addresses=["192.168.1.200"],
@@ -162,8 +162,6 @@ async def test_zeroconf_already_configured(
     hass: HomeAssistant,
 ) -> None:
     """Test zeroconf aborts if device already configured (MAC-based unique_id)."""
-    from homeassistant.components.zeroconf import ZeroconfServiceInfo
-
     # Create a config entry with MAC-based unique_id
     existing_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -204,8 +202,6 @@ async def test_zeroconf_during_onboarding(
     mock_aiohttp_session,
 ) -> None:
     """Test zeroconf auto-creates entry during onboarding."""
-    from homeassistant.components.zeroconf import ZeroconfServiceInfo
-
     discovery_info = ZeroconfServiceInfo(
         ip_address="192.168.1.100",
         ip_addresses=["192.168.1.100"],
@@ -239,6 +235,7 @@ async def test_zeroconf_during_onboarding(
     # Zeroconf creates entry directly (no confirmation step)
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == "wican_test.local."
+    assert result["description_placeholders"]["webhook_url"] == result["data"]["webhook_url"]
 
 
 async def test_options_flow(
@@ -262,8 +259,6 @@ async def test_zeroconf_flow_user_declines(
     mock_aiohttp_session,
 ) -> None:
     """Test user can decline discovered device."""
-    from homeassistant.components.zeroconf import ZeroconfServiceInfo
-
     discovery_info = ZeroconfServiceInfo(
         ip_address="192.168.1.100",
         ip_addresses=["192.168.1.100"],
@@ -298,8 +293,6 @@ async def test_zeroconf_flow_legacy_firmware(
     mock_aiohttp_session,
 ) -> None:
     """Test zeroconf works with older firmware without MAC address."""
-    from homeassistant.components.zeroconf import ZeroconfServiceInfo
-
     discovery_info = ZeroconfServiceInfo(
         ip_address="192.168.1.100",
         ip_addresses=["192.168.1.100"],
@@ -335,6 +328,7 @@ async def test_zeroconf_flow_legacy_firmware(
         # Should create entry with fallback unique_id (hostname-based)
         assert result2["type"] == FlowResultType.CREATE_ENTRY
         assert result2["title"] == "wican_legacy.local."
+        assert result2["description_placeholders"]["webhook_url"] == result2["data"]["webhook_url"]
         # No MAC address in data for legacy firmware
         assert "mac" not in result2["data"] or not result2["data"].get("mac")
 
@@ -369,8 +363,6 @@ async def test_config_flow_zeroconf_discovery_with_mac_and_device_id(
     hass: HomeAssistant,
 ) -> None:
     """Test config flow via zeroconf discovery with MAC and device_id."""
-    from homeassistant.components.zeroconf import ZeroconfServiceInfo
-    
     # Use proper WiCAN service name pattern
     discovery_info = ZeroconfServiceInfo(
         ip_address="192.168.1.100",
@@ -396,8 +388,6 @@ async def test_zeroconf_device_id_fallback_unique_id(
     hass: HomeAssistant,
 ) -> None:
     """Test zeroconf flow using device_id when MAC is not available (line 102)."""
-    from homeassistant.components.zeroconf import ZeroconfServiceInfo
-
     discovery_info = ZeroconfServiceInfo(
         ip_address="192.168.1.100",
         ip_addresses=["192.168.1.100"],
@@ -427,8 +417,6 @@ async def test_zeroconf_hostname_fallback_unique_id(
     hass: HomeAssistant,
 ) -> None:
     """Test zeroconf flow using hostname when MAC and device_id are unavailable (line 103)."""
-    from homeassistant.components.zeroconf import ZeroconfServiceInfo
-
     discovery_info = ZeroconfServiceInfo(
         ip_address="192.168.1.100",
         ip_addresses=["192.168.1.100"],
@@ -454,7 +442,6 @@ async def test_zeroconf_confirm_webhook_url_exception(
     mock_aiohttp_session,
 ) -> None:
     """Test zeroconf confirmation handles webhook URL generation exception (lines 145-149)."""
-    from homeassistant.components.zeroconf import ZeroconfServiceInfo
     from unittest.mock import patch
 
     discovery_info = ZeroconfServiceInfo(
@@ -475,8 +462,11 @@ async def test_zeroconf_confirm_webhook_url_exception(
         data=discovery_info,
     )
 
-    # Now confirm with mocked get_url that raises exception
-    with patch("homeassistant.helpers.network.get_url", side_effect=Exception("URL error")):
+    # Now confirm with mocked URL resolution that falls back to the current request
+    with patch(
+        "custom_components.wican.config_flow.resolve_webhook_url",
+        return_value="http://192.168.1.10:8123/api/webhook/test_webhook_id",
+    ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {},
@@ -485,8 +475,7 @@ async def test_zeroconf_confirm_webhook_url_exception(
     assert result2["type"] == FlowResultType.CREATE_ENTRY
     # Title should be the hostname (discovered_name)
     assert result2["title"] == "wican_test.local."
-    # Webhook URL should fall back to <webhook_id: ...> format due to exception
-    assert "webhook_id" in result2["data"]
+    assert result2["data"]["webhook_url"] == result2["description_placeholders"]["webhook_url"]
 
 
 async def test_options_flow_when_config_entry_set(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -123,14 +123,25 @@ async def test_coordinator_normalize_sensor_value_voltage(
     """Test sensor value normalization for voltage."""
     coordinator = WiCANDataUpdateCoordinator(hass, mock_config_entry)
 
-    # Battery voltage with "V" suffix
+    # Standard format (no space before unit)
     assert coordinator.normalize_sensor_value("batt_voltage", "12.5V") == 12.5
     assert coordinator.normalize_sensor_value("batt_voltage", "11.3V") == 11.3
 
-    # Invalid voltage format
+    # Format with space before unit — reported firmware variant: "12 V"
+    assert coordinator.normalize_sensor_value("batt_voltage", "12.5 V") == 12.5
+    assert coordinator.normalize_sensor_value("batt_voltage", "12 V") == 12.0
+
+    # Lowercase unit suffix
+    assert coordinator.normalize_sensor_value("batt_voltage", "12.5v") == 12.5
+    assert coordinator.normalize_sensor_value("batt_voltage", "12.5 v") == 12.5
+
+    # Leading/trailing whitespace in the whole string
+    assert coordinator.normalize_sensor_value("batt_voltage", " 12.5V ") == 12.5
+
+    # Invalid voltage format — should return raw string
     assert coordinator.normalize_sensor_value("batt_voltage", "invalid") == "invalid"
 
-    # Non-voltage key
+    # Non-voltage key — should not strip "V"
     assert coordinator.normalize_sensor_value("other_key", "12.5V") == "12.5V"
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -9,7 +9,9 @@ import pytest
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.const import CONF_WEBHOOK_ID
+from homeassistant.helpers.network import NoURLAvailableError
 
+from custom_components.wican import _async_register_webhook_on_device
 from custom_components.wican.const import DOMAIN
 
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -169,6 +171,53 @@ async def test_webhook_no_duplicate_registration(
     
     # Integration is working - no errors means no spurious re-registrations
     assert entry.state == ConfigEntryState.LOADED
+
+
+async def test_webhook_registration_no_url_available(
+    hass: HomeAssistant,
+    mock_aiohttp_session,
+) -> None:
+    """Test webhook registration falls back to stored webhook_url."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="WiCAN Device",
+        data={
+            "mdns": "http://wican_test.local:80",
+            "host": "http://wican_test.local:80",
+            CONF_WEBHOOK_ID: "test_webhook_id",
+            "webhook_url": "http://192.168.1.10:8123/api/webhook/test_webhook_id",
+        },
+        unique_id="wican_test-192.168.1.100:80",
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.wican._async_register_webhook_on_device",
+        return_value=True,
+    ):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    entry = config_entry
+    session = AsyncMock()
+    response = AsyncMock()
+    response.status = 200
+    session.post.return_value = response
+
+    with (
+        patch(
+            "custom_components.wican.webhook.async_generate_url",
+            side_effect=NoURLAvailableError,
+        ),
+        patch(
+            "custom_components.wican.async_get_clientsession",
+            return_value=session,
+        ),
+    ):
+        assert await _async_register_webhook_on_device(hass, entry) is True
+
+    session.post.assert_awaited()
+    assert session.post.await_args.kwargs["json"]["url"] == entry.data["webhook_url"]
 
 
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -169,6 +169,18 @@ async def test_sensor_voltage_normalization(
         assert batt_voltage_state.state == expected_state
 
 
+async def test_batt_voltage_sets_decimal_display_precision(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Test battery voltage sensor requests decimal display precision."""
+    entity_registry = er.async_get(hass)
+
+    batt_voltage = entity_registry.async_get("sensor.wican_device_batt_voltage")
+    assert batt_voltage is not None
+    assert batt_voltage.options.get("sensor", {}).get("suggested_display_precision") == 1
+
+
 async def test_sensor_state_restoration(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,


### PR DESCRIPTION
## Changes

- Added a shared helper to resolve the best available absolute webhook URL
- Stored the generated webhook URL in the config entry during setup
- Added fallback to the stored webhook URL during webhook registration when Home Assistant URL resolution is unavailable
- Improved battery voltage parsing to handle values with spaces, lowercase `v`, and surrounding whitespace
- Set battery voltage sensor display precision to 1 decimal place
- Added `FUEL_L` and `LV_A` parameter definitions