### PR TITLE
Fix binary sensor extra attributes never being populated

### DIFF
--- a/custom_components/wican/binary_sensor.py
+++ b/custom_components/wican/binary_sensor.py
@@ -62,7 +62,9 @@ class WiCANBinarySensorEntity(WiCANEntity, BinarySensorEntity, RestoreEntity):
         # If key not present, don't change state. Availability handled below.
         if key in status:
             self._attr_is_on = is_true_status(status[key])
-            self._attr_extra_state_attributes = get_sensor_attributes(key, self.coordinator.data)
+            self._attr_extra_state_attributes = get_sensor_attributes(
+                self.entity_description, self.coordinator.data,
+            )
 
         # Availability: if we have a status dict, entity is available; if device stopped pushing,
         # HA will keep last state, but we still emit state writes on updates to ensure logbook records.

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -249,3 +249,40 @@ async def test_binary_sensor_none_checks(hass: HomeAssistant, hass_client) -> No
     # Verify entities exist and didn't crash
     state = hass.states.get("binary_sensor.wican_test_ble_status")
     assert state is not None
+
+
+async def test_binary_sensor_extra_attributes_populated(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_webhook_data: dict,
+    hass_client,
+) -> None:
+    """Extra attributes declared on the description reach the entity state.
+
+    Regression test: the handler passed the description's key instead of the
+    description itself, so extra_attributes was always looked up on a string
+    and every binary sensor reported an empty attribute set.
+    """
+    entry = init_integration
+    webhook_id = entry.data[CONF_WEBHOOK_ID]
+
+    data = dict(mock_webhook_data)
+    data["status"] = {
+        **mock_webhook_data["status"],
+        "ble_status": "enable",
+        "ble_power": "9",
+        "ecu_status": "online",
+        "obd_chip_status": "ready",
+    }
+
+    client = await hass_client()
+    await client.post(f"/api/webhook/{webhook_id}", json=data)
+    await hass.async_block_till_done()
+
+    ble_state = hass.states.get("binary_sensor.wican_device_ble_status")
+    assert ble_state is not None
+    assert ble_state.attributes.get("ble_power") == "9"
+
+    ecu_state = hass.states.get("binary_sensor.wican_device_ecu_status")
+    assert ecu_state is not None
+    assert ecu_state.attributes.get("obd_chip_status") == "ready"


### PR DESCRIPTION
_handle_coordinator_update() passed the description's key rather than the description itself to get_sensor_attributes(), which reads extra_attributes off its first argument. getattr() on a plain string always fell back to the default, so the attribute set was empty and ble_power and obd_chip_status never appeared on the binary sensors.

The sensor platform already passes the description; do the same here.