### PR TITLE
Stop binary sensors restoring "unavailable" as "off"

### DIFF
--- a/custom_components/wican/binary_sensor.py
+++ b/custom_components/wican/binary_sensor.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
 )
+from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.restore_state import RestoreEntity
 
@@ -76,8 +77,15 @@ class WiCANBinarySensorEntity(WiCANEntity, BinarySensorEntity, RestoreEntity):
 
     async def async_added_to_hass(self) -> None:
         """Restore entity state."""
-        # Restore last known state so logbook has a baseline before first push
+        # Restore last known state so logbook has a baseline before first push.
+        # Only on/off are a known state: comparing against "on" would turn a
+        # restored "unavailable" or "unknown" into a fabricated "off", which
+        # reads as a real measurement the device never reported.
         last_state = await self.async_get_last_state()
-        if last_state is not None and self._attr_is_on is None:
-            self._attr_is_on = last_state.state == "on"
+        if (
+            last_state is not None
+            and self._attr_is_on is None
+            and last_state.state in (STATE_ON, STATE_OFF)
+        ):
+            self._attr_is_on = last_state.state == STATE_ON
         await super().async_added_to_hass()

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -6,13 +6,19 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.const import CONF_WEBHOOK_ID, STATE_ON, STATE_OFF
-from homeassistant.core import HomeAssistant
+from homeassistant.const import (
+    CONF_WEBHOOK_ID,
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+)
+from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers import entity_registry as er
 
 from custom_components.wican.const import DOMAIN
 
-from pytest_homeassistant_custom_component.common import MockConfigEntry
+from pytest_homeassistant_custom_component.common import MockConfigEntry, mock_restore_cache
 
 
 async def test_binary_sensor_entities_created(
@@ -249,3 +255,41 @@ async def test_binary_sensor_none_checks(hass: HomeAssistant, hass_client) -> No
     # Verify entities exist and didn't crash
     state = hass.states.get("binary_sensor.wican_test_ble_status")
     assert state is not None
+
+
+@pytest.mark.parametrize(
+    ("restored", "expected"),
+    [
+        (STATE_ON, STATE_ON),
+        (STATE_OFF, STATE_OFF),
+        # Neither of these is a state the device ever reported, so the entity
+        # must not claim to know it is off
+        (STATE_UNAVAILABLE, STATE_UNKNOWN),
+        (STATE_UNKNOWN, STATE_UNKNOWN),
+    ],
+)
+async def test_binary_sensor_restore_does_not_fabricate_off(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    restored: str,
+    expected: str,
+) -> None:
+    """A restored unavailable/unknown state must not come back as off.
+
+    The comparison used to be `last_state.state == "on"`, so anything that
+    was not literally "on" - including a state recorded while the device was
+    unreachable - restored as a confident "off".
+    """
+    mock_config_entry.add_to_hass(hass)
+    mock_restore_cache(hass, [State("binary_sensor.wican_device_ble_status", restored)])
+
+    with patch(
+        "custom_components.wican._async_register_webhook_on_device",
+        return_value=True,
+    ):
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.wican_device_ble_status")
+    assert state is not None
+    assert state.state == expected


### PR DESCRIPTION
async_added_to_hass() restored with `last_state.state == "on"`, so anything that was not literally "on" came back as "off" - including "unavailable" and "unknown". A state recorded while the device was unreachable therefore restored as a confident "off", which reads as a real measurement the device never took.

Only on and off are a known state; anything else leaves is_on as None so the entity reports "unknown" until the device says otherwise.

This matches WiCANPidBinarySensorEntity, which already guards this way, so all the binary sensors now behave the same on restore.