### PR TITLE
Give every platform the same device identity

### DIFF
--- a/custom_components/wican/__init__.py
+++ b/custom_components/wican/__init__.py
@@ -351,6 +351,7 @@ async def async_setup_entry(  # noqa: C901, PLR0915
     # Normalize host/mdns schemes BEFORE scheduling registration
     # to avoid triggering update listener which would cause duplicate registrations
     _normalize_connection_urls(hass, entry)
+    _normalize_entry_title(hass, entry)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
@@ -367,6 +368,24 @@ async def async_unload_entry(
     """Unload a config entry."""
     webhook.async_unregister(hass, entry.runtime_data.webhook_id)
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+
+def _normalize_entry_title(hass: HomeAssistant, entry: WiCANConfigEntry) -> None:
+    """Drop the trailing dot a zeroconf hostname carries.
+
+    Entries created before this was fixed are titled with the fully qualified
+    hostname ("wican_xxx.local."), and since the title is the device name
+    every entity ends up called "wican_xxx.local. batt_voltage".
+
+    Runs alongside _normalize_connection_urls() during setup, before the
+    update listener is registered, for the same reason: updating the entry
+    later would re-register the webhook on the device.
+    """
+    title = entry.title
+    normalized = title.rstrip(".")
+    if normalized and normalized != title:
+        _LOGGER.debug("Normalizing entry title %r to %r", title, normalized)
+        hass.config_entries.async_update_entry(entry, title=normalized)
 
 
 def _normalize_connection_urls(hass: HomeAssistant, entry: WiCANConfigEntry) -> None:

--- a/custom_components/wican/config_flow.py
+++ b/custom_components/wican/config_flow.py
@@ -129,10 +129,13 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         _LOGGER.info("WiCAN discovered via Zeroconf: name=%s hostname=%s url=%s", name, hostname, mdns_url)
 
-        # Store discovery info for confirmation step
+        # Store discovery info for confirmation step. Zeroconf hostnames are
+        # fully qualified and end in a dot ("wican_xxx.local."); using that
+        # verbatim as the device name leaves every entity called
+        # "wican_xxx.local. batt_voltage".
         self.discovered_mdns = mdns_url
         self.discovered_host = host_url
-        self.discovered_name = hostname or name
+        self.discovered_name = (hostname or name).rstrip(".") or None
         self.discovered_unique_id = unique_id
         self.discovered_mac = mac_address
         self.discovered_device_id = device_id

--- a/custom_components/wican/device_tracker.py
+++ b/custom_components/wican/device_tracker.py
@@ -11,13 +11,13 @@ from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.device_tracker import SourceType, TrackerEntity
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .entity import build_device_info
 
 if TYPE_CHECKING:
+    from homeassistant.helpers.device_registry import DeviceInfo
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
     from . import WiCANConfigEntry
@@ -80,31 +80,9 @@ class WiCANDeviceTrackerEntity(CoordinatorEntity, TrackerEntity, RestoreEntity):
         self._heading: float | None = None
 
     @property
-    def device_info(self):
+    def device_info(self) -> DeviceInfo:
         """Return device info for this entity."""
-        info = self.config_entry.data
-        device_id = info.get("device_id") or self.config_entry.entry_id
-        config_url = info.get("mdns")
-        if not isinstance(config_url, str) or not config_url.startswith("http"):
-            config_url = None
-
-        device_info_dict = {
-            "identifiers": {(DOMAIN, device_id)},
-            "manufacturer": "MeatPi",
-            "model": info.get("hw_version", "Unknown"),
-            "name": "WiCAN Device",
-            "sw_version": info.get("fw_version", "Unknown"),
-            "configuration_url": config_url,
-        }
-
-        mac_address = info.get("mac")
-        if mac_address:
-            device_info_dict["connections"] = {(CONNECTION_NETWORK_MAC, mac_address)}
-
-        if info.get("device_id"):
-            device_info_dict["serial_number"] = info.get("device_id")
-
-        return DeviceInfo(**device_info_dict)
+        return build_device_info(self.config_entry)
 
     @property
     def source_type(self) -> SourceType:

--- a/custom_components/wican/entity.py
+++ b/custom_components/wican/entity.py
@@ -19,6 +19,50 @@ if TYPE_CHECKING:
     from . import WiCANConfigEntry
 
 
+def build_device_info(config_entry: WiCANConfigEntry) -> DeviceInfo:
+    """Build the device registry entry for a WiCAN device.
+
+    Every platform must agree on this, in particular on the name: the
+    device_tracker used to hardcode "WiCAN Device" while everything else used
+    the config entry title, and since both register under the same
+    identifiers the device ended up named inconsistently and the tracker's
+    entity_id was derived from the wrong one.
+
+    Args:
+        config_entry: The config entry the entity belongs to.
+
+    Returns:
+        DeviceInfo describing the device.
+    """
+    info = config_entry.data
+    config_url = info.get("mdns")
+    if not isinstance(config_url, str) or not config_url.startswith("http"):
+        config_url = None
+
+    # Use device_id or MAC as stable identifier (survives hostname changes)
+    device_id = info.get("device_id") or config_entry.entry_id
+
+    device_info_dict = {
+        "identifiers": {(DOMAIN, device_id)},
+        "manufacturer": "MeatPi",
+        "model": info.get("hw_version", "Unknown"),
+        "name": config_entry.title,
+        "sw_version": info.get("fw_version", "Unknown"),
+        "configuration_url": config_url,
+    }
+
+    # Add MAC address connection if available (from firmware)
+    mac_address = info.get("mac")
+    if mac_address:
+        device_info_dict["connections"] = {(CONNECTION_NETWORK_MAC, mac_address)}
+
+    # Add serial number if device_id available
+    if info.get("device_id"):
+        device_info_dict["serial_number"] = info.get("device_id")
+
+    return DeviceInfo(**device_info_dict)
+
+
 class WiCANEntity(CoordinatorEntity[WiCANDataUpdateCoordinator]):
     """Base entity using DataUpdateCoordinator."""
 
@@ -74,31 +118,4 @@ class WiCANEntity(CoordinatorEntity[WiCANDataUpdateCoordinator]):
     @property
     def device_info(self) -> DeviceInfo:
         """Return device info."""
-        info = self.config_entry.data
-        config_url = info.get("mdns")
-        if not isinstance(config_url, str) or not config_url.startswith("http"):
-            config_url = None
-
-        # Use device_id or MAC as stable identifier (survives hostname changes)
-        device_id = info.get("device_id") or self.config_entry.entry_id
-
-        # Build device info with MAC connection if available
-        device_info_dict = {
-            "identifiers": {(DOMAIN, device_id)},
-            "manufacturer": "MeatPi",
-            "model": info.get("hw_version", "Unknown"),
-            "name": self.config_entry.title,
-            "sw_version": info.get("fw_version", "Unknown"),
-            "configuration_url": config_url,
-        }
-
-        # Add MAC address connection if available (from firmware)
-        mac_address = info.get("mac")
-        if mac_address:
-            device_info_dict["connections"] = {(CONNECTION_NETWORK_MAC, mac_address)}
-
-        # Add serial number if device_id available
-        if info.get("device_id"):
-            device_info_dict["serial_number"] = info.get("device_id")
-
-        return DeviceInfo(**device_info_dict)
+        return build_device_info(self.config_entry)

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 from homeassistant.components.device_tracker import SourceType
 from homeassistant.const import STATE_HOME, STATE_NOT_HOME, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -387,3 +387,34 @@ async def test_device_tracker_gps_parse_error_logging(
     entity_id = "device_tracker.wican_device_location"
     state = hass.states.get(entity_id)
     assert state.state == STATE_UNAVAILABLE
+
+
+async def test_device_tracker_shares_the_device_with_the_sensors(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """The tracker registers against the same device, under the same name.
+
+    It used to hardcode the device name as "WiCAN Device" while every other
+    platform used the config entry title. Both register under the same
+    identifiers, so the device ended up named inconsistently and the
+    tracker's entity_id was derived from the wrong one.
+    """
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
+
+    tracker = entity_registry.async_get("device_tracker.wican_device_location")
+    sensor = entity_registry.async_get("sensor.wican_device_batt_voltage")
+    assert tracker is not None
+    assert sensor is not None
+
+    # One device, not two
+    assert tracker.device_id == sensor.device_id
+
+    device = device_registry.async_get(tracker.device_id)
+    assert device is not None
+    assert device.name == mock_config_entry.title

--- a/tests/test_init_helpers.py
+++ b/tests/test_init_helpers.py
@@ -16,6 +16,7 @@ from custom_components.wican import (
     _build_webhook_endpoint,
     _normalize_ip,
     _extract_request_ip,
+    _normalize_entry_title,
 )
 
 
@@ -261,3 +262,42 @@ def test_extract_request_ip_transport_empty_peername():
     
     result = _extract_request_ip(request)
     assert result == "10.0.0.6"
+
+
+def test_normalize_entry_title_strips_trailing_dot():
+    """A fully qualified zeroconf hostname loses its trailing dot."""
+    hass = MagicMock()
+    entry = MagicMock()
+    entry.title = "wican_70af09217a91.local."
+
+    _normalize_entry_title(hass, entry)
+
+    hass.config_entries.async_update_entry.assert_called_once_with(
+        entry, title="wican_70af09217a91.local",
+    )
+
+
+def test_normalize_entry_title_leaves_clean_titles_alone():
+    """An already-clean title does not trigger a config entry write.
+
+    Writing the entry fires the update listener, which re-registers the
+    webhook on the device.
+    """
+    hass = MagicMock()
+    entry = MagicMock()
+    entry.title = "wican_70af09217a91.local"
+
+    _normalize_entry_title(hass, entry)
+
+    hass.config_entries.async_update_entry.assert_not_called()
+
+
+def test_normalize_entry_title_ignores_all_dots():
+    """A title that is nothing but dots is left as-is rather than emptied."""
+    hass = MagicMock()
+    entry = MagicMock()
+    entry.title = "..."
+
+    _normalize_entry_title(hass, entry)
+
+    hass.config_entries.async_update_entry.assert_not_called()


### PR DESCRIPTION
Two problems that both surface as a wrong device name.

device_tracker.py built its own DeviceInfo with the name hardcoded to "WiCAN Device", while entity.py used the config entry title. Both register under the same identifiers, so the device registry ended up with an inconsistent name and the tracker's entity_id was derived from the wrong one: an entity dump from a real device shows device_tracker.wican_device_location alongside
sensor.wican_70af09217a91_local_* for everything else. Both now call a shared build_device_info() in entity.py, which is otherwise the code that was already there.

Zeroconf hostnames are fully qualified and end in a dot, and the config flow used the hostname verbatim as the entry title, so the device was named "wican_70af09217a91.local." and every entity read "wican_70af09217a91.local. batt_voltage". Strip it, and migrate entries created before this with _normalize_entry_title().

The migration runs next to _normalize_connection_urls() during setup, before the update listener is registered - updating the entry afterwards would re-register the webhook on the device. It also leaves an already-clean title alone rather than writing the entry unnecessarily.