### PR TITLE
Give newly discovered PID entities their first value immediately

### DIFF
--- a/custom_components/wican/coordinator.py
+++ b/custom_components/wican/coordinator.py
@@ -42,6 +42,12 @@ class WiCANDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             update_interval=UPDATE_INTERVAL,
             config_entry=config_entry,
         )
+        # DataUpdateCoordinator.data is None until a refresh completes, but
+        # entities read self.coordinator.data.get(...) unconditionally. This
+        # is push-based (see async_config_entry_first_refresh below), so
+        # there is nothing to wait for - seed it now instead of leaving a
+        # None that only stops being a footgun after the first webhook.
+        self.data = self._data
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from WiCAN device.

--- a/custom_components/wican/entity.py
+++ b/custom_components/wican/entity.py
@@ -55,6 +55,17 @@ class WiCANEntity(CoordinatorEntity[WiCANDataUpdateCoordinator]):
         """Register event callback."""
         await super().async_added_to_hass()
 
+        # Seed current state from the coordinator now that any subclass
+        # restore logic (which runs before this via super().async_added_to_hass())
+        # has had a chance to set a last-known value. Dynamically discovered
+        # PID entities are created from the very webhook payload that first
+        # reports them, so self.coordinator.data already holds their value by
+        # this point - but the listener registered above only fires on the
+        # *next* update, so without this the entity would show
+        # unknown/unavailable until then. Existing entities just get their
+        # already-current value written again, which is a harmless no-op.
+        self._handle_coordinator_update()
+
         # Keep dispatcher for backward compatibility during migration
         @callback
         def _handle_event_filtered(webhook_id: str, data: dict[str, str]) -> None:

--- a/custom_components/wican/sensor.py
+++ b/custom_components/wican/sensor.py
@@ -301,7 +301,7 @@ class WiCANSensorEntity(WiCANEntity, RestoreSensor):
 class WiCANPidSensorEntity(WiCANEntity, RestoreSensor):
     """Dynamic PID sensor entity."""
 
-    __slots__ = ("_attr_native_value", "_pending_value", "_pid_key")
+    __slots__ = ("_attr_native_value", "_pid_key")
 
     entity_description: WiCANSensorEntityDescription
 
@@ -311,7 +311,6 @@ class WiCANPidSensorEntity(WiCANEntity, RestoreSensor):
         self._pid_key = pid_key
         self._attr_unique_id = f"{config_entry.entry_id}_pid_{pid_key}"
         self._attr_entity_category = None  # Regular sensor
-        self._pending_value = None
         self._attr_native_value = None  # Initialize to None
 
     def _handle_coordinator_update(self) -> None:
@@ -334,12 +333,8 @@ class WiCANPidSensorEntity(WiCANEntity, RestoreSensor):
         """
 
     async def async_added_to_hass(self) -> None:
-        """Restore entity state and set pending value if present."""
+        """Restore entity state."""
         state = await self.async_get_last_sensor_data()
         if state:
             self._attr_native_value = state.native_value
-        if self._pending_value is not None:
-            self._attr_native_value = self._pending_value
-            self.async_write_ha_state()
-            self._pending_value = None
         await super().async_added_to_hass()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -30,8 +30,10 @@ async def test_coordinator_initialization(
     # Coordinator name is the domain (lowercase)
     assert coordinator.name == "wican"
     assert coordinator.update_interval == timedelta(minutes=5)
-    # Data is None until first update
-    assert coordinator.data is None
+    # Seeded with an empty dict rather than the DataUpdateCoordinator default
+    # of None, since this integration is push-based: there is no "first
+    # update" to wait for, and entities read coordinator.data unconditionally.
+    assert coordinator.data == {}
 
 
 async def test_coordinator_first_refresh(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -299,3 +299,34 @@ async def test_sensor_state_restoration_with_normalization(hass: HomeAssistant) 
 
 
 
+
+
+async def test_new_pid_sensor_has_a_value_on_the_webhook_that_created_it(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    hass_client,
+) -> None:
+    """A first-seen PID must show its value immediately, not on the next update.
+
+    WiCANPidSensorEntity used to rely on a _pending_value set from
+    _async_handle_event(), a dispatcher callback that stopped running once
+    entity updates moved to the coordinator pattern. The entity was still
+    created with the value already in hand (the same webhook payload that
+    revealed the PID), but nothing ever wrote it, so the state stayed
+    unknown until a second, unrelated webhook arrived.
+    """
+    entry = init_integration
+    webhook_id = entry.data[CONF_WEBHOOK_ID]
+
+    data = {
+        "autopid_data": {"CTRL_MOD_V": 13.8},
+        "config": {"CTRL_MOD_V": {"unit": "V", "class": "voltage"}},
+    }
+
+    client = await hass_client()
+    await client.post(f"/api/webhook/{webhook_id}", json=data)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.wican_device_ctrl_mod_v")
+    assert state is not None
+    assert state.state == "13.8"


### PR DESCRIPTION
A brand-new PID sensor/binary_sensor is built from the very webhook payload that reveals it, but it showed unknown until the *next*, unrelated update arrived. The mechanism meant to prevent this, _pending_value on WiCANPidSensorEntity, was dead: it was only ever populated by _async_handle_event(), the pre-coordinator dispatcher callback, which the coordinator refactor turned into a no-op stub. WiCANPidBinarySensorEntity never had an equivalent at all.

Fixed once, in the shared base class: WiCANEntity.async_added_to_hass() now calls self._handle_coordinator_update() after the coordinator listener is registered (and after any subclass restore-from-storage logic, which runs first via super().async_added_to_hass()). Every _handle_coordinator_update() already no-ops when its key isn't in the coordinator data, so this is a harmless extra write for already-populated entities and the missing seed for new ones. Removed the dead _pending_value plumbing from sensor.py.

That seed call surfaced a second, latent bug: DataUpdateCoordinator.data is None until a refresh completes, and every _handle_coordinator_update() in this integration reads self.coordinator.data.get(...) unconditionally. Calling it from async_added_to_hass() meant doing so before setup's first refresh had a chance to run, so any entity whose PID/status key happened to already be present (or, for update.py, any entity at all) crashed instead of no-oping. This integration is push-based - the "first refresh" is a formality with no fetch behind it - so WiCANDataUpdateCoordinator now seeds coordinator.data with its (empty) store at construction instead of leaving HA's None default in place.

Added a regression test posting a single webhook that introduces a new PID and asserting the sensor has its value straight away.