### PR TITLE
Drop dynamic PID entities when the config entry unloads

### DIFF
--- a/custom_components/wican/sensor.py
+++ b/custom_components/wican/sensor.py
@@ -137,10 +137,12 @@ def _normalize_device_class(
     return device_class
 
 
+# Entities created dynamically from webhook data, keyed by config entry id.
+# Entries are dropped when the config entry unloads - see _async_forget_entry().
 DYNAMIC_PID_SENSORS = {}
 
 
-async def async_setup_entry(  # noqa: C901
+async def async_setup_entry(  # noqa: C901, PLR0915
     hass: HomeAssistant,
     config_entry: WiCANConfigEntry,
     async_add_entities: AddEntitiesCallback,
@@ -153,6 +155,13 @@ async def async_setup_entry(  # noqa: C901
     )
 
     DYNAMIC_PID_SENSORS[config_entry.entry_id] = {}
+
+    @callback
+    def _async_forget_entry() -> None:
+        """Drop this entry's entity map so removed entries leave nothing behind."""
+        DYNAMIC_PID_SENSORS.pop(config_entry.entry_id, None)
+
+    config_entry.async_on_unload(_async_forget_entry)
 
     # Restore PID sensors from config entry
     pid_keys = config_entry.data.get("pid_keys", [])
@@ -191,7 +200,11 @@ async def async_setup_entry(  # noqa: C901
 
         pid_config = data.get("config", {})
         new_entities = []
-        sensors = DYNAMIC_PID_SENSORS[config_entry.entry_id]
+        # A webhook can already be queued when the entry unloads, so the map
+        # may be gone by the time this task runs.
+        sensors = DYNAMIC_PID_SENSORS.get(config_entry.entry_id)
+        if sensors is None:
+            return
 
         for pid_key in pid_data:
             if pid_key not in sensors:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -9,8 +9,10 @@ import pytest
 from homeassistant.const import CONF_WEBHOOK_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from custom_components.wican.const import DOMAIN
+from custom_components.wican.sensor import DYNAMIC_PID_SENSORS
 
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -299,3 +301,54 @@ async def test_sensor_state_restoration_with_normalization(hass: HomeAssistant) 
 
 
 
+
+
+async def test_dynamic_pid_map_cleared_on_unload(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_webhook_data: dict,
+    hass_client,
+) -> None:
+    """The module-level entity map does not outlive the config entry.
+
+    DYNAMIC_PID_SENSORS is keyed by entry id and was only ever assigned, so
+    every removed entry left its entities behind for the lifetime of the
+    process.
+    """
+    entry = init_integration
+    webhook_id = entry.data[CONF_WEBHOOK_ID]
+
+    data = dict(mock_webhook_data)
+    data["autopid_data"] = {"SOC": 62}
+    data["config"] = {"SOC": {"unit": "%", "class": "battery"}}
+
+    client = await hass_client()
+    await client.post(f"/api/webhook/{webhook_id}", json=data)
+    await hass.async_block_till_done()
+
+    assert entry.entry_id in DYNAMIC_PID_SENSORS
+    assert "SOC" in DYNAMIC_PID_SENSORS[entry.entry_id]
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.entry_id not in DYNAMIC_PID_SENSORS
+
+
+async def test_webhook_after_unload_is_ignored(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_webhook_data: dict,
+) -> None:
+    """A webhook still in flight when the entry unloads does not raise."""
+    entry = init_integration
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    data = dict(mock_webhook_data)
+    data["autopid_data"] = {"SOC": 62}
+    data["config"] = {"SOC": {"unit": "%", "class": "battery"}}
+
+    async_dispatcher_send(hass, DOMAIN, entry.data[CONF_WEBHOOK_ID], data)
+    await hass.async_block_till_done()


### PR DESCRIPTION
DYNAMIC_PID_SENSORS is a module-level dict keyed by entry id that was only ever assigned to, so removing a WiCAN device left its entity map - and through it every entity object - alive for the rest of the process.

Register an on_unload callback to drop the entry's map, and read it with .get() in the webhook handler: a webhook can already be queued when the entry unloads, and the handler would then raise KeyError.