### PR TITLE
Give standard OBD-II PIDs the metadata params.json lacks

### DIFF
--- a/custom_components/wican/param_loader.py
+++ b/custom_components/wican/param_loader.py
@@ -77,6 +77,8 @@ DEVICE_CLASS_ICONS: Final[dict[str, str]] = {
 PARAM_NAME_ICONS: Final[dict[str, str]] = {
     # Engine
     "engine_rpm": "mdi:engine",
+    "engine_load": "mdi:engine",
+    "timing_adv": "mdi:timer-cog-outline",
     # Fuel
     "fuel": "mdi:fuel",
     "fuel_rate": "mdi:gas-station",
@@ -100,6 +102,7 @@ PARAM_NAME_ICONS: Final[dict[str, str]] = {
     "oilch_dis": "mdi:oil",
     # Battery/Voltage (12V)
     "lv_v": "mdi:car-battery",
+    "ctrl_mod_v": "mdi:car-battery",
     "alt_duty": "mdi:current-ac",
     # EV Battery/SOC
     "soc": "mdi:battery",
@@ -433,6 +436,65 @@ _PID_ALIASES: Final[dict[str, str]] = {
 }
 
 
+# params.json describes vehicle-profile parameters (SOC, HV_V, RANGE, ...), not
+# standard OBD-II Mode 01 PIDs, so six of the names _PID_ALIASES maps to have
+# never existed in it - the lookup silently returned nothing for the PIDs most
+# vehicles actually support. These fill that gap.
+#
+# Units match what obd2_standard_pids.h reports for the same PID, so a sensor
+# built from this fallback and one built from the device's own config agree and
+# HA does not see the unit change underneath it.
+_STANDARD_PID_FALLBACKS: Final[dict[str, ParamDefinition]] = {
+    # PID 0x46
+    "AMBIENT_TMP": {
+        "description": "Ambient Air Temperature",
+        "settings": {"unit": "°C", "class": "temperature"},
+    },
+    # PID 0x33
+    "BARO_PRES": {
+        "description": "Absolute Barometric Pressure",
+        "settings": {"unit": "kPa", "class": "pressure"},
+    },
+    # PID 0x42
+    "CTRL_MOD_V": {
+        "description": "Control Module Voltage",
+        "settings": {"unit": "V", "class": "voltage"},
+    },
+    # PID 0x21
+    "DIST_MIL": {
+        "description": "Distance Travelled With MIL On",
+        "settings": {"unit": "km", "class": "distance"},
+    },
+    # PID 0x04
+    "ENGINE_LOAD": {
+        "description": "Calculated Engine Load",
+        "settings": {"unit": "%", "class": "none"},
+    },
+    # PID 0x0E
+    "TIMING_ADV": {
+        "description": "Timing Advance",
+        "settings": {"unit": "deg", "class": "none"},
+    },
+}
+
+
+def _lookup_param(param_name: str) -> ParamDefinition | None:
+    """Resolve a parameter definition by name.
+
+    params.json wins; the built-in standard-PID table fills the gaps it has.
+
+    Args:
+        param_name: Parameter name (case-insensitive, supports various formats).
+
+    Returns:
+        The parameter definition, or None if the name is unknown.
+    """
+    key = _normalize_param_name(param_name)
+    if key in _PARAMS:
+        return _PARAMS[key]
+    return _STANDARD_PID_FALLBACKS.get(key)
+
+
 # Valid Home Assistant sensor device classes
 # Invalid classes from firmware will be filtered out
 _VALID_HA_DEVICE_CLASSES: Final[set[str]] = {
@@ -609,11 +671,10 @@ def get_param_unit(param_name: str) -> str | None:
     Returns:
         Unit string or None if not found/empty.
     """
-    # Normalize to canonical params.json name
-    key = _normalize_param_name(param_name)
+    param = _lookup_param(param_name)
 
-    if key in _PARAMS:
-        unit = _PARAMS[key].get("settings", {}).get("unit", "")
+    if param is not None:
+        unit = param.get("settings", {}).get("unit", "")
         # Return None for empty/none units
         if unit and unit.lower() not in ("", "none"):
             return unit
@@ -630,10 +691,10 @@ def get_param_device_class(param_name: str) -> str | None:
     Returns:
         Device class string or None if not found/invalid.
     """
-    key = _normalize_param_name(param_name)
+    param = _lookup_param(param_name)
 
-    if key in _PARAMS:
-        device_class = _PARAMS[key].get("settings", {}).get("class", "")
+    if param is not None:
+        device_class = param.get("settings", {}).get("class", "")
         # Return None for empty/none classes
         if device_class and device_class.lower() not in ("", "none"):
             return device_class
@@ -685,10 +746,10 @@ def get_param_description(param_name: str) -> str | None:
     Returns:
         Description string or None if not found.
     """
-    key = _normalize_param_name(param_name)
+    param = _lookup_param(param_name)
 
-    if key in _PARAMS:
-        return _PARAMS[key].get("description")
+    if param is not None:
+        return param.get("description")
 
     return None
 
@@ -702,10 +763,10 @@ def is_binary_sensor(param_name: str) -> bool:
     Returns:
         True if parameter is defined as binary_sensor type.
     """
-    key = _normalize_param_name(param_name)
+    param = _lookup_param(param_name)
 
-    if key in _PARAMS:
-        return _PARAMS[key].get("settings", {}).get("type") == "binary_sensor"
+    if param is not None:
+        return param.get("settings", {}).get("type") == "binary_sensor"
 
     return False
 

--- a/tests/test_param_loader.py
+++ b/tests/test_param_loader.py
@@ -467,3 +467,63 @@ class TestGitHubParamsUpdate:
         params = get_all_params()
         assert isinstance(params, dict)
         assert "SOC" in params  # Known param should still exist
+
+class TestStandardPidFallbacks:
+    """Standard Mode 01 PIDs that params.json has never described."""
+
+    def test_control_module_voltage(self) -> None:
+        """PID 0x42 resolves through every alias spelling."""
+        for name in (
+            "42-ControlModuleVolt",
+            "42_ControlModuleVolt",
+            "ControlModuleVolt",
+            "CTRL_MOD_V",
+        ):
+            assert get_param_unit(name) == "V", name
+            assert get_param_device_class(name) == "voltage", name
+
+    def test_ambient_air_temperature(self) -> None:
+        """PID 0x46 resolves to the unit HA accepts for temperature."""
+        for name in ("46-AmbientAirTemp", "AmbientAirTemp", "AMBIENT_TMP"):
+            assert get_param_unit(name) == "°C", name
+            assert get_param_device_class(name) == "temperature", name
+
+    def test_remaining_gap_pids(self) -> None:
+        """The other four alias targets that pointed at nothing."""
+        assert get_param_unit("33-AbsBaroPres") == "kPa"
+        assert get_param_device_class("33-AbsBaroPres") == "pressure"
+
+        assert get_param_unit("21-DistanceMILOn") == "km"
+        assert get_param_device_class("21-DistanceMILOn") == "distance"
+
+        assert get_param_unit("04-CalcEngineLoad") == "%"
+        assert get_param_device_class("04-CalcEngineLoad") is None
+
+        assert get_param_unit("0E-TimingAdvance") == "deg"
+        assert get_param_device_class("0E-TimingAdvance") is None
+
+    def test_descriptions_available(self) -> None:
+        """Fallbacks carry a description like params.json entries do."""
+        assert get_param_description("42-ControlModuleVolt") == "Control Module Voltage"
+        assert get_param_description("46-AmbientAirTemp") == "Ambient Air Temperature"
+
+    def test_fallbacks_are_not_binary_sensors(self) -> None:
+        """None of the fallbacks declare a binary_sensor type."""
+        for name in ("42-ControlModuleVolt", "46-AmbientAirTemp", "04-CalcEngineLoad"):
+            assert is_binary_sensor(name) is False, name
+
+    def test_icons_resolve(self) -> None:
+        """PIDs without a device class still get a meaningful icon."""
+        assert get_param_icon("04-CalcEngineLoad", None) == "mdi:engine"
+        assert get_param_icon("0E-TimingAdvance", None) == "mdi:timer-cog-outline"
+
+    def test_params_json_still_wins(self) -> None:
+        """A name present in params.json is not shadowed by the fallbacks."""
+        assert get_param_unit("SOC") == "%"
+        assert get_param_unit("05-EngineCoolantTemp") == "°C"
+
+    def test_unknown_name_still_returns_none(self) -> None:
+        """Names in neither source keep returning None."""
+        assert get_param_unit("totally_unknown") is None
+        assert get_param_device_class("totally_unknown") is None
+        assert get_param_description("totally_unknown") is None


### PR DESCRIPTION
_PID_ALIASES maps 16 standard Mode 01 PID spellings onto canonical names, but six of those names - AMBIENT_TMP, BARO_PRES, CTRL_MOD_V, DIST_MIL, ENGINE_LOAD and TIMING_ADV - are not in params.json and never have been. params.json describes vehicle-profile parameters (SOC, HV_V, RANGE), not standard PIDs, so every lookup for those six returned nothing and the fallback path was dead code.

Add a small built-in table for them and route the lookups through _lookup_param(), which prefers params.json and falls back to the table. Units match what obd2_standard_pids.h reports for the same PID, so a sensor built from the fallback agrees with one built from the device's own config payload.