### PR TITLE
Record the device's own 12V reading as a measurement

### DIFF
--- a/custom_components/wican/attributes.py
+++ b/custom_components/wican/attributes.py
@@ -1,7 +1,11 @@
 from dataclasses import dataclass, field
 
 from homeassistant.components.binary_sensor import BinarySensorEntityDescription
-from homeassistant.components.sensor import SensorDeviceClass, SensorEntityDescription
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntityDescription,
+    SensorStateClass,
+)
 from homeassistant.helpers.entity import EntityCategory
 
 
@@ -33,6 +37,7 @@ SENSOR_DESCRIPTIONS: tuple[WiCANSensorEntityDescription, ...] = (
         icon="mdi:car-battery",
         device_class=SensorDeviceClass.VOLTAGE,
         native_unit_of_measurement="V",
+        state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
         extra_attributes=[
             "batt_alert",

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -299,3 +299,44 @@ async def test_sensor_state_restoration_with_normalization(hass: HomeAssistant) 
 
 
 
+
+
+async def test_batt_voltage_is_a_measurement(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_webhook_data: dict,
+    hass_client,
+) -> None:
+    """The device's own 12V reading is recorded as a measurement.
+
+    It had a device class, a unit and a display precision but no state
+    class, so it produced no long-term statistics - the same defect the
+    dynamic PID sensors had.
+    """
+    entry = init_integration
+    client = await hass_client()
+    await client.post(
+        f"/api/webhook/{entry.data[CONF_WEBHOOK_ID]}", json=mock_webhook_data,
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.wican_device_batt_voltage")
+    assert state is not None
+    assert state.attributes.get("state_class") == "measurement"
+    assert state.attributes.get("device_class") == "voltage"
+    assert state.attributes.get("unit_of_measurement") == "V"
+
+
+async def test_text_sensors_have_no_state_class(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+) -> None:
+    """The diagnostic text sensors must not be measurements."""
+    for entity_id in (
+        "sensor.wican_device_wifi_mode",
+        "sensor.wican_device_vpn_status",
+        "sensor.wican_device_uptime",
+    ):
+        state = hass.states.get(entity_id)
+        assert state is not None, entity_id
+        assert state.attributes.get("state_class") is None, entity_id


### PR DESCRIPTION
batt_voltage already declared a voltage device class, a unit and a display precision, but no state class, so Home Assistant kept no long-term statistics for it.

The three text sensors (wifi_mode, vpn_status, uptime) deliberately keep no state class: HA raises on a measurement sensor whose state is not numeric.