### PR TITLE
Import ZeroconfServiceInfo from wherever the installed HA keeps it

### DIFF
--- a/custom_components/wican/config_flow.py
+++ b/custom_components/wican/config_flow.py
@@ -26,7 +26,15 @@ if TYPE_CHECKING:
     from ipaddress import IPv4Address, IPv6Address
 
     from homeassistant.data_entry_flow import FlowResult
-    from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
+
+    # ZeroconfServiceInfo moved between HA releases: it lived in
+    # helpers.service_info.zeroconf from 2025.2 until the deprecated aliases
+    # were cleaned up in 2026, before that and after that it is in
+    # components.zeroconf. Try both so type checkers work on any HA version.
+    try:
+        from homeassistant.components.zeroconf import ZeroconfServiceInfo
+    except ImportError:
+        from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -4,17 +4,22 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, patch
 
-import pytest
-
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
-from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
+import pytest
+
+# ZeroconfServiceInfo moved between HA releases: see config_flow.py for the
+# same compatibility dance.
+try:
+    from homeassistant.components.zeroconf import ZeroconfServiceInfo
+except ImportError:
+    from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
+
 from homeassistant.const import CONF_NAME, CONF_WEBHOOK_ID
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.wican.const import DOMAIN
-
-from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 
 async def test_user_flow_success(


### PR DESCRIPTION
ZeroconfServiceInfo lived in homeassistant.helpers.service_info.zeroconf from HA 2025.2 until the deprecated aliases were cleaned up in 2026; before and after that it is in homeassistant.components.zeroconf. The old import path therefore only existed for a few releases, and the test suite failed to collect on any other HA version.

Try the current location first, falling back to the historical one.