### PR TITLE
Sync bundled params.json with wican-fw main and merge instead of replace

### DIFF
--- a/custom_components/wican/data/params.json
+++ b/custom_components/wican/data/params.json
@@ -10,7 +10,7 @@
     "description": "AC Charging Current",
     "settings": {
       "unit": "A",
-      "class": "battery"
+      "class": "current"
     }
   },
   "AC_C_V": {
@@ -25,6 +25,25 @@
     "settings": {
       "unit": "",
       "class": "none"
+    }
+  },
+  "AC_PLUG": {
+    "description": "Normal Charge Port",
+    "settings": {
+      "unit": "",
+      "type": "binary_sensor",
+      "class": "none",
+      "min": "0",
+      "max": "1"
+    }
+  },
+  "AIRBAG": {
+    "description": "Airbag H/wire Duty",
+    "settings": {
+      "unit": "",
+      "class": "none",
+      "min": "50",
+      "max": "100"
     }
   },
   "ALT_DUTY": {
@@ -48,6 +67,23 @@
       "class": "temperature",
       "min": "-40",
       "max": "80"
+    }
+  },
+  "CABIN_TEMPERATURE": {
+    "description": "Cabin temperature",
+    "settings": {
+      "unit": "°C",
+      "class": "temperature",
+      "max": "100"
+    }
+  },
+  "CAPACITOR": {
+    "description": "Inverter Capacitor Voltage",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "840"
     }
   },
   "CHARGER_CONNECTED": {
@@ -81,6 +117,22 @@
       "type": "binary_sensor"
     }
   },
+  "CHARGING_R_A": {
+    "description": "Requested Charge Current",
+    "settings": {
+      "unit": "A",
+      "class": "current",
+      "min": "0",
+      "max": "200"
+    }
+  },
+  "CO2": {
+    "description": "CO2 Concentration",
+    "settings": {
+      "unit": "ppm",
+      "class": "carbon_dioxide"
+    }
+  },
   "COOLANT_TMP": {
     "description": "Coolant Temperature",
     "settings": {
@@ -94,6 +146,24 @@
       "unit": "km",
       "class": "distance",
       "min": "0"
+    }
+  },
+  "DM_F_RPM": {
+    "description": "Drive Motor Speed Front",
+    "settings": {
+      "unit": "rpm",
+      "class": "none",
+      "min": "-10100",
+      "max": "10100"
+    }
+  },
+  "DM_R_RPM": {
+    "description": "Drive Motor Speed Rear",
+    "settings": {
+      "unit": "rpm",
+      "class": "none",
+      "min": "-10100",
+      "max": "10100"
     }
   },
   "DRIVE_MODE": {
@@ -181,6 +251,13 @@
       "class": "none"
     }
   },
+  "HUMIDITY": {
+    "description": "Humidity",
+    "settings": {
+      "unit": "%",
+      "class": "humidity"
+    }
+  },
   "HV_A": {
     "description": "High Voltage Battery current",
     "settings": {
@@ -188,11 +265,29 @@
       "class": "current"
     }
   },
+  "HV_AH_CHARGED": {
+    "description": "Cumulative Charge Current",
+    "settings": {
+      "unit": "Ah",
+      "class": "none",
+      "min": "0",
+      "max": "1000000"
+    }
+  },
+  "HV_AH_DISCHARGED": {
+    "description": "Cumulative Discharge Current",
+    "settings": {
+      "unit": "Ah",
+      "class": "none",
+      "min": "0",
+      "max": "1000000"
+    }
+  },
   "HV_AV": {
     "description": "High Voltage Battery Power Available",
     "settings": {
       "unit": "kW",
-      "class": "battery"
+      "class": "power"
     }
   },
   "HV_CAPACITY": {
@@ -206,14 +301,23 @@
     "description": "HV Battery capacity in kWh",
     "settings": {
       "unit": "kWh",
-      "class": "none"
+      "class": "energy"
     }
   },
   "HV_CAPACITY_R": {
     "description": "HV Battery capacity Remaining",
     "settings": {
       "unit": "kWh",
-      "class": "none"
+      "class": "energy"
+    }
+  },
+  "HV_C_DIFF": {
+    "description": "Battery Cell Voltage Deviation",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "4"
     }
   },
   "HV_C_D_MAX": {
@@ -244,6 +348,1734 @@
       "class": "none"
     }
   },
+  "HV_C_V_001": {
+    "description": "Cell Voltage 001",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_002": {
+    "description": "Cell Voltage 002",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_003": {
+    "description": "Cell Voltage 003",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_004": {
+    "description": "Cell Voltage 004",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_005": {
+    "description": "Cell Voltage 005",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_006": {
+    "description": "Cell Voltage 006",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_007": {
+    "description": "Cell Voltage 007",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_008": {
+    "description": "Cell Voltage 008",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_009": {
+    "description": "Cell Voltage 009",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_010": {
+    "description": "Cell Voltage 010",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_011": {
+    "description": "Cell Voltage 011",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_012": {
+    "description": "Cell Voltage 012",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_013": {
+    "description": "Cell Voltage 013",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_014": {
+    "description": "Cell Voltage 014",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_015": {
+    "description": "Cell Voltage 015",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_016": {
+    "description": "Cell Voltage 016",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_017": {
+    "description": "Cell Voltage 017",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_018": {
+    "description": "Cell Voltage 018",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_019": {
+    "description": "Cell Voltage 019",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_020": {
+    "description": "Cell Voltage 020",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_021": {
+    "description": "Cell Voltage 021",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_022": {
+    "description": "Cell Voltage 022",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_023": {
+    "description": "Cell Voltage 023",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_024": {
+    "description": "Cell Voltage 024",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_025": {
+    "description": "Cell Voltage 025",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_026": {
+    "description": "Cell Voltage 026",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_027": {
+    "description": "Cell Voltage 027",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_028": {
+    "description": "Cell Voltage 028",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_029": {
+    "description": "Cell Voltage 029",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_030": {
+    "description": "Cell Voltage 030",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_031": {
+    "description": "Cell Voltage 031",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_032": {
+    "description": "Cell Voltage 032",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_033": {
+    "description": "Cell Voltage 033",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_034": {
+    "description": "Cell Voltage 034",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_035": {
+    "description": "Cell Voltage 035",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_036": {
+    "description": "Cell Voltage 036",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_037": {
+    "description": "Cell Voltage 037",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_038": {
+    "description": "Cell Voltage 038",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_039": {
+    "description": "Cell Voltage 039",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_040": {
+    "description": "Cell Voltage 040",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_041": {
+    "description": "Cell Voltage 041",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_042": {
+    "description": "Cell Voltage 042",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_043": {
+    "description": "Cell Voltage 043",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_044": {
+    "description": "Cell Voltage 044",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_045": {
+    "description": "Cell Voltage 045",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_046": {
+    "description": "Cell Voltage 046",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_047": {
+    "description": "Cell Voltage 047",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_048": {
+    "description": "Cell Voltage 048",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_049": {
+    "description": "Cell Voltage 049",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_050": {
+    "description": "Cell Voltage 050",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_051": {
+    "description": "Cell Voltage 051",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_052": {
+    "description": "Cell Voltage 052",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_053": {
+    "description": "Cell Voltage 053",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_054": {
+    "description": "Cell Voltage 054",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_055": {
+    "description": "Cell Voltage 055",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_056": {
+    "description": "Cell Voltage 056",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_057": {
+    "description": "Cell Voltage 057",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_058": {
+    "description": "Cell Voltage 058",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_059": {
+    "description": "Cell Voltage 059",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_060": {
+    "description": "Cell Voltage 060",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_061": {
+    "description": "Cell Voltage 061",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_062": {
+    "description": "Cell Voltage 062",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_063": {
+    "description": "Cell Voltage 063",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_064": {
+    "description": "Cell Voltage 064",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_065": {
+    "description": "Cell Voltage 065",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_066": {
+    "description": "Cell Voltage 066",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_067": {
+    "description": "Cell Voltage 067",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_068": {
+    "description": "Cell Voltage 068",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_069": {
+    "description": "Cell Voltage 069",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_070": {
+    "description": "Cell Voltage 070",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_071": {
+    "description": "Cell Voltage 071",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_072": {
+    "description": "Cell Voltage 072",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_073": {
+    "description": "Cell Voltage 073",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_074": {
+    "description": "Cell Voltage 074",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_075": {
+    "description": "Cell Voltage 075",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_076": {
+    "description": "Cell Voltage 076",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_077": {
+    "description": "Cell Voltage 077",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_078": {
+    "description": "Cell Voltage 078",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_079": {
+    "description": "Cell Voltage 079",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_080": {
+    "description": "Cell Voltage 080",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_081": {
+    "description": "Cell Voltage 081",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_082": {
+    "description": "Cell Voltage 082",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_083": {
+    "description": "Cell Voltage 083",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_084": {
+    "description": "Cell Voltage 084",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_085": {
+    "description": "Cell Voltage 085",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_086": {
+    "description": "Cell Voltage 086",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_087": {
+    "description": "Cell Voltage 087",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_088": {
+    "description": "Cell Voltage 088",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_089": {
+    "description": "Cell Voltage 089",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_090": {
+    "description": "Cell Voltage 090",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_091": {
+    "description": "Cell Voltage 091",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_092": {
+    "description": "Cell Voltage 092",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_093": {
+    "description": "Cell Voltage 093",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_094": {
+    "description": "Cell Voltage 094",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_095": {
+    "description": "Cell Voltage 095",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_096": {
+    "description": "Cell Voltage 096",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_097": {
+    "description": "Cell Voltage 097",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_098": {
+    "description": "Cell Voltage 098",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_099": {
+    "description": "Cell Voltage 099",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_100": {
+    "description": "Cell Voltage 100",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_101": {
+    "description": "Cell Voltage 101",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_102": {
+    "description": "Cell Voltage 102",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_103": {
+    "description": "Cell Voltage 103",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_104": {
+    "description": "Cell Voltage 104",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_105": {
+    "description": "Cell Voltage 105",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_106": {
+    "description": "Cell Voltage 106",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_107": {
+    "description": "Cell Voltage 107",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_108": {
+    "description": "Cell Voltage 108",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_109": {
+    "description": "Cell Voltage 109",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_110": {
+    "description": "Cell Voltage 110",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_111": {
+    "description": "Cell Voltage 111",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_112": {
+    "description": "Cell Voltage 112",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_113": {
+    "description": "Cell Voltage 113",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_114": {
+    "description": "Cell Voltage 114",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_115": {
+    "description": "Cell Voltage 115",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_116": {
+    "description": "Cell Voltage 116",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_117": {
+    "description": "Cell Voltage 117",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_118": {
+    "description": "Cell Voltage 118",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_119": {
+    "description": "Cell Voltage 119",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_120": {
+    "description": "Cell Voltage 120",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_121": {
+    "description": "Cell Voltage 121",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_122": {
+    "description": "Cell Voltage 122",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_123": {
+    "description": "Cell Voltage 123",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_124": {
+    "description": "Cell Voltage 124",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_125": {
+    "description": "Cell Voltage 125",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_126": {
+    "description": "Cell Voltage 126",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_127": {
+    "description": "Cell Voltage 127",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_128": {
+    "description": "Cell Voltage 128",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_129": {
+    "description": "Cell Voltage 129",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_130": {
+    "description": "Cell Voltage 130",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_131": {
+    "description": "Cell Voltage 131",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_132": {
+    "description": "Cell Voltage 132",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_133": {
+    "description": "Cell Voltage 133",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_134": {
+    "description": "Cell Voltage 134",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_135": {
+    "description": "Cell Voltage 135",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_136": {
+    "description": "Cell Voltage 136",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_137": {
+    "description": "Cell Voltage 137",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_138": {
+    "description": "Cell Voltage 138",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_139": {
+    "description": "Cell Voltage 139",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_140": {
+    "description": "Cell Voltage 140",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_141": {
+    "description": "Cell Voltage 141",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_142": {
+    "description": "Cell Voltage 142",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_143": {
+    "description": "Cell Voltage 143",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_144": {
+    "description": "Cell Voltage 144",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_145": {
+    "description": "Cell Voltage 145",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_146": {
+    "description": "Cell Voltage 146",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_147": {
+    "description": "Cell Voltage 147",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_148": {
+    "description": "Cell Voltage 148",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_149": {
+    "description": "Cell Voltage 149",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_150": {
+    "description": "Cell Voltage 150",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_151": {
+    "description": "Cell Voltage 151",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_152": {
+    "description": "Cell Voltage 152",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_153": {
+    "description": "Cell Voltage 153",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_154": {
+    "description": "Cell Voltage 154",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_155": {
+    "description": "Cell Voltage 155",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_156": {
+    "description": "Cell Voltage 156",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_157": {
+    "description": "Cell Voltage 157",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_158": {
+    "description": "Cell Voltage 158",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_159": {
+    "description": "Cell Voltage 159",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_160": {
+    "description": "Cell Voltage 160",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_161": {
+    "description": "Cell Voltage 161",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_162": {
+    "description": "Cell Voltage 162",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_163": {
+    "description": "Cell Voltage 163",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_164": {
+    "description": "Cell Voltage 164",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_165": {
+    "description": "Cell Voltage 165",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_166": {
+    "description": "Cell Voltage 166",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_167": {
+    "description": "Cell Voltage 167",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_168": {
+    "description": "Cell Voltage 168",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_169": {
+    "description": "Cell Voltage 169",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_170": {
+    "description": "Cell Voltage 170",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_171": {
+    "description": "Cell Voltage 171",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_172": {
+    "description": "Cell Voltage 172",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_173": {
+    "description": "Cell Voltage 173",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_174": {
+    "description": "Cell Voltage 174",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_175": {
+    "description": "Cell Voltage 175",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_176": {
+    "description": "Cell Voltage 176",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_177": {
+    "description": "Cell Voltage 177",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_178": {
+    "description": "Cell Voltage 178",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_179": {
+    "description": "Cell Voltage 179",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_180": {
+    "description": "Cell Voltage 180",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_181": {
+    "description": "Cell Voltage 181",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_182": {
+    "description": "Cell Voltage 182",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_183": {
+    "description": "Cell Voltage 183",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_184": {
+    "description": "Cell Voltage 184",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_185": {
+    "description": "Cell Voltage 185",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_186": {
+    "description": "Cell Voltage 186",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_187": {
+    "description": "Cell Voltage 187",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_188": {
+    "description": "Cell Voltage 188",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_189": {
+    "description": "Cell Voltage 189",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_190": {
+    "description": "Cell Voltage 190",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_191": {
+    "description": "Cell Voltage 191",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
+  "HV_C_V_192": {
+    "description": "Cell Voltage 192",
+    "settings": {
+      "unit": "V",
+      "class": "battery",
+      "min": "0",
+      "max": "10"
+    }
+  },
   "HV_C_V_MAX": {
     "description": "HV Battery Highest cell voltage",
     "settings": {
@@ -272,11 +2104,129 @@
       "class": "none"
     }
   },
+  "HV_H_1": {
+    "description": "Battery Heater 1 Temperature",
+    "settings": {
+      "unit": "°C",
+      "class": "temperature",
+      "min": "0",
+      "max": "80"
+    }
+  },
+  "HV_KWH_R": {
+    "description": "Battery Remaining Energy",
+    "settings": {
+      "unit": "Wh",
+      "class": "energy",
+      "min": "0",
+      "max": "77000"
+    }
+  },
+  "HV_RELAY": {
+    "description": "BMS Main Relay",
+    "settings": {
+      "unit": "",
+      "type": "binary_sensor",
+      "class": "none",
+      "min": "0",
+      "max": "1"
+    }
+  },
   "HV_T_1": {
     "description": "HV Battery Temp Sensor 1",
     "settings": {
       "unit": "°C",
       "class": "temperature"
+    }
+  },
+  "HV_T_10": {
+    "description": "HV Battery Temp Sensor 10",
+    "settings": {
+      "unit": "°C",
+      "class": "temperature",
+      "min": "-40",
+      "max": "80"
+    }
+  },
+  "HV_T_11": {
+    "description": "HV Battery Temp Sensor 11",
+    "settings": {
+      "unit": "°C",
+      "class": "temperature",
+      "min": "-40",
+      "max": "80"
+    }
+  },
+  "HV_T_12": {
+    "description": "HV Battery Temp Sensor 12",
+    "settings": {
+      "unit": "°C",
+      "class": "temperature",
+      "min": "-40",
+      "max": "80"
+    }
+  },
+  "HV_T_13": {
+    "description": "HV Battery Temp Sensor 13",
+    "settings": {
+      "unit": "°C",
+      "class": "temperature",
+      "min": "-40",
+      "max": "80"
+    }
+  },
+  "HV_T_14": {
+    "description": "HV Battery Temp Sensor 14",
+    "settings": {
+      "unit": "°C",
+      "class": "temperature",
+      "min": "-40",
+      "max": "80"
+    }
+  },
+  "HV_T_15": {
+    "description": "HV Battery Temp Sensor 15",
+    "settings": {
+      "unit": "°C",
+      "class": "temperature",
+      "min": "-40",
+      "max": "80"
+    }
+  },
+  "HV_T_16": {
+    "description": "HV Battery Temp Sensor 16",
+    "settings": {
+      "unit": "°C",
+      "class": "temperature",
+      "min": "-40",
+      "max": "80"
+    }
+  },
+  "HV_T_17": {
+    "description": "HV Battery Temp Sensor 17",
+    "settings": {
+      "unit": "°C",
+      "class": "temperature",
+      "min": "-40",
+      "max": "80"
+    }
+  },
+  "HV_T_18": {
+    "description": "HV Battery Temp Sensor 18",
+    "settings": {
+      "unit": "°C",
+      "class": "temperature",
+      "min": "-40",
+      "max": "80"
+    }
+  },
+  "HV_T_19": {
+    "description": "HV Battery Temp Sensor 19",
+    "settings": {
+      "unit": "°C",
+      "class": "temperature",
+      "min": "-40",
+      "max": "80"
     }
   },
   "HV_T_2": {
@@ -286,11 +2236,155 @@
       "class": "temperature"
     }
   },
+  "HV_T_20": {
+    "description": "HV Battery Temp Sensor 20",
+    "settings": {
+      "unit": "°C",
+      "class": "temperature",
+      "min": "-40",
+      "max": "80"
+    }
+  },
+  "HV_T_21": {
+    "description": "HV Battery Temp Sensor 21",
+    "settings": {
+      "unit": "°C",
+      "class": "temperature",
+      "min": "-40",
+      "max": "80"
+    }
+  },
+  "HV_T_22": {
+    "description": "HV Battery Temp Sensor 22",
+    "settings": {
+      "unit": "°C",
+      "class": "temperature",
+      "min": "-40",
+      "max": "80"
+    }
+  },
+  "HV_T_23": {
+    "description": "HV Battery Temp Sensor 23",
+    "settings": {
+      "unit": "°C",
+      "class": "temperature",
+      "min": "-40",
+      "max": "80"
+    }
+  },
+  "HV_T_24": {
+    "description": "HV Battery Temp Sensor 24",
+    "settings": {
+      "unit": "°C",
+      "class": "temperature",
+      "min": "-40",
+      "max": "80"
+    }
+  },
+  "HV_T_25": {
+    "description": "HV Battery Temp Sensor 25",
+    "settings": {
+      "unit": "°C",
+      "class": "temperature",
+      "min": "-40",
+      "max": "80"
+    }
+  },
+  "HV_T_26": {
+    "description": "HV Battery Temp Sensor 26",
+    "settings": {
+      "unit": "°C",
+      "class": "temperature",
+      "min": "-40",
+      "max": "80"
+    }
+  },
+  "HV_T_27": {
+    "description": "HV Battery Temp Sensor 27",
+    "settings": {
+      "unit": "°C",
+      "class": "temperature",
+      "min": "-40",
+      "max": "80"
+    }
+  },
+  "HV_T_28": {
+    "description": "HV Battery Temp Sensor 28",
+    "settings": {
+      "unit": "°C",
+      "class": "temperature",
+      "min": "-40",
+      "max": "80"
+    }
+  },
+  "HV_T_29": {
+    "description": "HV Battery Temp Sensor 29",
+    "settings": {
+      "unit": "°C",
+      "class": "temperature",
+      "min": "-40",
+      "max": "80"
+    }
+  },
   "HV_T_3": {
     "description": "HV Battery Temp Sensor 3",
     "settings": {
       "unit": "°C",
       "class": "temperature"
+    }
+  },
+  "HV_T_30": {
+    "description": "HV Battery Temp Sensor 30",
+    "settings": {
+      "unit": "°C",
+      "class": "temperature",
+      "min": "-40",
+      "max": "80"
+    }
+  },
+  "HV_T_31": {
+    "description": "HV Battery Temp Sensor 31",
+    "settings": {
+      "unit": "°C",
+      "class": "temperature",
+      "min": "-40",
+      "max": "80"
+    }
+  },
+  "HV_T_32": {
+    "description": "HV Battery Temp Sensor 32",
+    "settings": {
+      "unit": "°C",
+      "class": "temperature",
+      "min": "-40",
+      "max": "80"
+    }
+  },
+  "HV_T_33": {
+    "description": "HV Battery Temp Sensor 33",
+    "settings": {
+      "unit": "°C",
+      "class": "temperature",
+      "min": "-40",
+      "max": "80"
+    }
+  },
+  "HV_T_34": {
+    "description": "HV Battery Temp Sensor 34",
+    "settings": {
+      "unit": "°C",
+      "class": "temperature",
+      "min": "-40",
+      "max": "80"
+    }
+  },
+  "HV_T_35": {
+    "description": "HV Battery Temp Sensor 35",
+    "settings": {
+      "unit": "°C",
+      "class": "temperature",
+      "min": "-40",
+      "max": "80"
     }
   },
   "HV_T_4": {
@@ -305,6 +2399,42 @@
     "settings": {
       "unit": "°C",
       "class": "temperature"
+    }
+  },
+  "HV_T_6": {
+    "description": "HV Battery Temp Sensor 6",
+    "settings": {
+      "unit": "°C",
+      "class": "temperature",
+      "min": "-40",
+      "max": "80"
+    }
+  },
+  "HV_T_7": {
+    "description": "HV Battery Temp Sensor 7",
+    "settings": {
+      "unit": "°C",
+      "class": "temperature",
+      "min": "-40",
+      "max": "80"
+    }
+  },
+  "HV_T_8": {
+    "description": "HV Battery Temp Sensor 8",
+    "settings": {
+      "unit": "°C",
+      "class": "temperature",
+      "min": "-40",
+      "max": "80"
+    }
+  },
+  "HV_T_9": {
+    "description": "HV Battery Temp Sensor 9",
+    "settings": {
+      "unit": "°C",
+      "class": "temperature",
+      "min": "-40",
+      "max": "80"
     }
   },
   "HV_T_A": {
@@ -351,6 +2481,16 @@
       "class": "power"
     }
   },
+  "IGNITION": {
+    "description": "BMS Ignition",
+    "settings": {
+      "unit": "",
+      "type": "binary_sensor",
+      "class": "none",
+      "min": "0",
+      "max": "1"
+    }
+  },
   "INTAKE_AIR_TEMP_2": {
     "description": "Air Intake Temperature 2",
     "settings": {
@@ -366,10 +2506,21 @@
     }
   },
   "KWH_CHARGED": {
-    "description": "Total kWh Charged",
+    "description": "Total kWh Charged (Cumulative Energy Charged)",
     "settings": {
-      "unit": "kwh",
-      "class": "battery"
+      "unit": "kWh",
+      "class": "energy",
+      "min": "0",
+      "max": "1000000"
+    }
+  },
+  "KWH_DISCHARGED": {
+    "description": "Total kWH Discharged( Cumulative Energy Discharged)",
+    "settings": {
+      "unit": "kWh",
+      "class": "energy",
+      "min": "0",
+      "max": "1000000"
     }
   },
   "LV_A": {
@@ -377,6 +2528,15 @@
     "settings": {
       "unit": "A",
       "class": "current"
+    }
+  },
+  "LV_SOC": {
+    "description": "12v Battery State of Charge",
+    "settings": {
+      "unit": "%",
+      "class": "battery",
+      "min": "0",
+      "max": "100"
     }
   },
   "LV_V": {
@@ -408,6 +2568,14 @@
       "min": "0"
     }
   },
+  "ODOMETER_MI": {
+    "description": "Vehicle odometer in miles",
+    "settings": {
+      "class": "distance",
+      "unit": "mi",
+      "min": "0"
+    }
+  },
   "OILCH_DIS": {
     "description": "Distance till next oil change",
     "settings": {
@@ -420,6 +2588,23 @@
     "settings": {
       "unit": "%",
       "class": "none"
+    }
+  },
+  "OP_TIME": {
+    "description": "Operating Time",
+    "settings": {
+      "unit": "hours",
+      "class": "none",
+      "min": "0",
+      "max": "1000000"
+    }
+  },
+  "OUTSIDE_TEMPERATURE": {
+    "description": "Outside temperature",
+    "settings": {
+      "unit": "°C",
+      "class": "temperature",
+      "max": "100"
     }
   },
   "PARK_BRAKE": {
@@ -531,6 +2716,15 @@
       "class": "power"
     }
   },
+  "RESISTANCE": {
+    "description": "Isolation Resistance",
+    "settings": {
+      "unit": "kOhm",
+      "class": "none",
+      "min": "0",
+      "max": "1000"
+    }
+  },
   "SOC": {
     "description": "State Of Charge",
     "settings": {
@@ -575,6 +2769,15 @@
     "settings": {
       "unit": "km/h",
       "class": "speed"
+    }
+  },
+  "STEER_ANGLE": {
+    "description": "Steering Angle",
+    "settings": {
+      "unit": "deg",
+      "class": "none",
+      "min": "-720",
+      "max": "720"
     }
   },
   "STFT": {

--- a/custom_components/wican/param_loader.py
+++ b/custom_components/wican/param_loader.py
@@ -266,6 +266,10 @@ async def async_fetch_params_from_github(
 async def async_update_params_from_github(session: ClientSession) -> bool:
     """Fetch params.json from GitHub and update local file if changed.
 
+    Parameters that exist locally but not upstream are kept. Users running a
+    firmware fork add parameters for their own vehicle profile, and replacing
+    the file wholesale silently dropped them on the next setup.
+
     Args:
         session: aiohttp ClientSession to use for the request.
 
@@ -287,25 +291,41 @@ async def async_update_params_from_github(session: ClientSession) -> bool:
         _LOGGER.debug("params.json is up to date (hash: %s...)", current_hash[:8])
         return False
 
+    # Upstream wins on conflicts; locally added parameters are preserved.
+    merged_params = dict(new_params)
+    local_only = [key for key in _PARAMS if key not in new_params]
+    if local_only:
+        _LOGGER.debug(
+            "Keeping %d locally added parameter(s) not present upstream: %s",
+            len(local_only),
+            ", ".join(sorted(local_only)),
+        )
+        for key in local_only:
+            merged_params[key] = _PARAMS[key]
+
+    if merged_params == _PARAMS:
+        _LOGGER.debug("params.json content is already up to date")
+        return False
+
     # Write updated params to file
     params_file = _get_params_file_path()
     try:
         def _write_params() -> None:
             params_file.parent.mkdir(parents=True, exist_ok=True)
             with params_file.open("w", encoding="utf-8") as f:
-                json.dump(new_params, f, indent=2, ensure_ascii=False)
+                json.dump(merged_params, f, indent=2, ensure_ascii=False)
 
         await asyncio.to_thread(_write_params)
 
         _LOGGER.info(
             "Updated params.json from GitHub: %d parameters (hash: %s...)",
-            len(new_params),
+            len(merged_params),
             new_hash[:8] if new_hash else "unknown",
         )
 
         # Update in-memory params
         _PARAMS.clear()
-        _PARAMS.update(new_params)
+        _PARAMS.update(merged_params)
     except OSError as err:
         _LOGGER.warning("Failed to write updated params.json: %s", err)
         return False

--- a/tests/test_param_loader.py
+++ b/tests/test_param_loader.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import json
+from unittest.mock import AsyncMock, patch
+
 import pytest
 
 from custom_components.wican.param_loader import (
@@ -13,6 +16,8 @@ from custom_components.wican.param_loader import (
     get_all_params,
      is_valid_device_class,
     is_valid_class_unit_combo,
+    async_update_params_from_github,
+    _PARAMS,
     DEFAULT_PARAM_ICON,
 )
 
@@ -175,7 +180,7 @@ class TestEvParameters:
     def test_ev_charging_params(self) -> None:
         """Test EV charging parameters are loaded correctly."""
         assert get_param_unit("CHARGER_DC_PWR") == "kW"
-        assert get_param_unit("KWH_CHARGED") == "kwh"
+        assert get_param_unit("KWH_CHARGED") == "kWh"
         assert get_param_unit("AC_C_C") == "A"
         assert get_param_unit("AC_C_V") == "V"
 
@@ -467,3 +472,94 @@ class TestGitHubParamsUpdate:
         params = get_all_params()
         assert isinstance(params, dict)
         assert "SOC" in params  # Known param should still exist
+
+class TestAsyncUpdateParamsFromGithub:
+    """Tests for async_update_params_from_github merge behaviour."""
+
+    @pytest.fixture
+    def restore_params(self):
+        """Restore the module-level params after each test."""
+        original = dict(_PARAMS)
+        yield
+        _PARAMS.clear()
+        _PARAMS.update(original)
+
+    @pytest.mark.usefixtures("restore_params")
+    async def test_locally_added_params_are_kept(self, tmp_path) -> None:
+        """A parameter only present locally survives an upstream refresh."""
+        local_only = {"description": "Local", "settings": {"unit": "rpm", "class": "none"}}
+        _PARAMS.clear()
+        _PARAMS.update({"SOC": {"description": "Old", "settings": {"unit": "%"}}})
+        _PARAMS["MOTOR_RPM"] = local_only
+
+        upstream = {"SOC": {"description": "New", "settings": {"unit": "%"}}}
+        params_file = tmp_path / "params.json"
+
+        with patch(
+            "custom_components.wican.param_loader.async_fetch_params_from_github",
+            AsyncMock(return_value=(upstream, "newhash")),
+        ), patch(
+            "custom_components.wican.param_loader._async_get_current_params_hash",
+            AsyncMock(return_value="oldhash"),
+        ), patch(
+            "custom_components.wican.param_loader._get_params_file_path",
+            return_value=params_file,
+        ):
+            assert await async_update_params_from_github(AsyncMock()) is True
+
+        # Upstream wins on shared keys, local-only key is preserved
+        assert _PARAMS["SOC"]["description"] == "New"
+        assert _PARAMS["MOTOR_RPM"] == local_only
+
+        written = json.loads(params_file.read_text(encoding="utf-8"))
+        assert written["MOTOR_RPM"] == local_only
+
+    @pytest.mark.usefixtures("restore_params")
+    async def test_no_rewrite_when_content_matches(self, tmp_path) -> None:
+        """An unchanged merge result does not rewrite the file."""
+        upstream = {"SOC": {"description": "Same", "settings": {"unit": "%"}}}
+        _PARAMS.clear()
+        _PARAMS.update(upstream)
+        params_file = tmp_path / "params.json"
+
+        with patch(
+            "custom_components.wican.param_loader.async_fetch_params_from_github",
+            AsyncMock(return_value=(dict(upstream), "newhash")),
+        ), patch(
+            "custom_components.wican.param_loader._async_get_current_params_hash",
+            AsyncMock(return_value="oldhash"),
+        ), patch(
+            "custom_components.wican.param_loader._get_params_file_path",
+            return_value=params_file,
+        ):
+            assert await async_update_params_from_github(AsyncMock()) is False
+
+        assert not params_file.exists()
+
+
+class TestSyncedParams:
+    """Parameters that only exist in the full upstream params.json."""
+
+    def test_ev_profile_params_present(self) -> None:
+        """Parameters an EV profile reports resolve to a unit and class."""
+        assert get_param_unit("OUTSIDE_TEMPERATURE") == "°C"
+        assert get_param_device_class("OUTSIDE_TEMPERATURE") == "temperature"
+        assert get_param_unit("LV_SOC") == "%"
+        assert get_param_unit("HV_AH_CHARGED") == "Ah"
+        assert get_param_unit("KWH_DISCHARGED") == "kWh"
+
+    def test_cell_voltage_params_present(self) -> None:
+        """Per-cell voltages were missing entirely from the trimmed copy."""
+        assert get_param_unit("HV_C_V_001") == "V"
+        assert get_param_unit("HV_C_V_192") == "V"
+
+    def test_binary_sensor_types_present(self) -> None:
+        """Profile flags carry their binary_sensor type."""
+        assert is_binary_sensor("AC_PLUG") is True
+        assert is_binary_sensor("IGNITION") is True
+
+    def test_energy_params_use_energy_class(self) -> None:
+        """Upstream corrects classes the trimmed copy had as "battery"."""
+        assert get_param_device_class("KWH_CHARGED") == "energy"
+        assert get_param_device_class("AC_C_C") == "current"
+        assert get_param_device_class("HV_AV") == "power"


### PR DESCRIPTION
The bundled copy had 92 of the 337 parameters the firmware repository defines, and was missing most of what an EV profile reports - among them OUTSIDE_TEMPERATURE, HV_AH_CHARGED, KWH_DISCHARGED, LV_SOC, IGNITION and every HV_C_V_nnn cell voltage. Until the integration managed to fetch an update from GitHub, those parameters had no unit, device class, description or binary-sensor type to fall back on. Taken verbatim from .vehicle_profiles/params.json on wican-fw main, so the file is byte-identical to what PARAMS_GITHUB_URL serves; the hash comparison in async_update_params_from_github() now short-circuits instead of rewriting the file on every setup.

The sync also exposed that async_update_params_from_github() replaced the whole file with the download, so a parameter defined only in a user's firmware fork was silently dropped on the next setup. Merge instead: upstream wins on keys present in both, local-only keys are kept. Also skip the write when the merged result matches what is already loaded, so a file that differs from upstream only by local additions is not rewritten on every setup.

Fixed three genuinely wrong classes the trimmed copy had along the way: KWH_CHARGED, AC_C_C and HV_AV were classed "battery", which Home Assistant rejects for kWh/A/kW; upstream gives them energy, current and power. One existing test asserted KWH_CHARGED's unit as "kwh"; it's spelled "kWh" upstream, corrected.