### PR TITLE
Give PID sensors a sensible display precision

### DIFF
--- a/custom_components/wican/param_loader.py
+++ b/custom_components/wican/param_loader.py
@@ -169,6 +169,78 @@ PARAM_NAME_ICONS: Final[dict[str, str]] = {
 DEFAULT_PARAM_ICON: Final[str] = "mdi:car-info"
 
 
+# Placeholder strings the firmware uses in the "unit" field to mean
+# "this value has no unit". "Encoded" is used by the 16 standard PIDs that
+# report packed bitfields (PIDsSupported, MonitorStatus, FuelSysStat, ...).
+_NON_UNITS: Final[frozenset[str]] = frozenset({"", "-", "encoded", "n/a", "none"})
+
+# Unit spellings used by the WiCAN firmware and by the upstream params.json
+# that Home Assistant does not recognise, mapped to the spelling HA expects.
+#
+# HA validates native_unit_of_measurement against the sensor's device class, so
+# a sensor reporting "degC" for a temperature device class loses its unit
+# conversion and its long-term statistics. obd2_standard_pids.h alone uses
+# "degC" for 13 PIDs (including 46-AmbientAirTemp), "volts" for 16 PIDs, and
+# "seconds"/"minutes"/"hours" for the duration PIDs.
+#
+# Keys are lower-cased; anything not listed here is passed through untouched.
+_UNIT_ALIASES: Final[dict[str, str]] = {
+    # Temperature
+    "degc": "°C",
+    "degf": "°F",
+    "degk": "K",
+    # Electrical
+    "volts": "V",
+    "volt": "V",
+    "millivolts": "mV",
+    "amps": "A",
+    "amp": "A",
+    "milliamps": "mA",
+    "watts": "W",
+    "watt": "W",
+    "kilowatts": "kW",
+    # Time
+    "seconds": "s",
+    "sec": "s",
+    "minutes": "min",
+    "mins": "min",
+    "hours": "h",
+    "hour": "h",
+    # Pressure (params.json spells kPa both "kPa" and "KPa")
+    "kpa": "kPa",
+    "hpa": "hPa",
+    # Flow rate
+    "grams/sec": "g/s",
+    # Speed
+    "kph": "km/h",
+    "km/hr": "km/h",
+    # Rotational speed (params.json spells it both "rpm" and "RPM")
+    "rpm": "rpm",
+}
+
+
+def normalize_unit(unit: str | None) -> str | None:
+    """Map a firmware unit string onto the spelling Home Assistant expects.
+
+    Args:
+        unit: Raw unit string from the device config or params.json.
+
+    Returns:
+        The canonical HA unit, or None when the string is a placeholder rather
+        than a real unit. Unrecognised units are returned stripped but
+        otherwise unchanged, so custom units still reach HA.
+    """
+    if unit is None:
+        return None
+
+    stripped = unit.strip()
+    lowered = stripped.lower()
+    if lowered in _NON_UNITS:
+        return None
+
+    return _UNIT_ALIASES.get(lowered, stripped)
+
+
 def _get_params_file_path() -> Path:
     """Get the path to the params.json file."""
     return Path(__file__).parent / "data" / "params.json"

--- a/custom_components/wican/sensor.py
+++ b/custom_components/wican/sensor.py
@@ -45,6 +45,55 @@ _NON_NUMERIC_DEVICE_CLASSES: frozenset[SensorDeviceClass] = frozenset(
 )
 
 
+# How many decimals to show, per device class. The firmware sends whatever
+# the profile's expression produces: cJSON drops the fraction on integral
+# doubles, so HV_V arrives as 345 rather than 345.0, while a km->mi
+# conversion leaves ODOMETER reading 50339.1443967231. Without a suggested
+# precision Home Assistant renders both verbatim.
+#
+# This is display only - the native value is what HA converts and records -
+# and HA rescales it automatically when the unit is converted, so a value
+# stored in km still shows sensibly in miles.
+#
+# Voltage gets two decimals so per-cell differences stay visible: at one
+# decimal every HV_C_V_nnn reads 3.9 and the cell delta disappears.
+_DEFAULT_PRECISION: dict[SensorDeviceClass, int] = {
+    SensorDeviceClass.ATMOSPHERIC_PRESSURE: 0,
+    SensorDeviceClass.BATTERY: 1,
+    SensorDeviceClass.CURRENT: 1,
+    SensorDeviceClass.DISTANCE: 1,
+    SensorDeviceClass.DURATION: 0,
+    SensorDeviceClass.ENERGY: 2,
+    SensorDeviceClass.ENERGY_STORAGE: 2,
+    SensorDeviceClass.FREQUENCY: 0,
+    SensorDeviceClass.POWER: 2,
+    SensorDeviceClass.POWER_FACTOR: 1,
+    SensorDeviceClass.PRESSURE: 0,
+    SensorDeviceClass.SPEED: 0,
+    SensorDeviceClass.TEMPERATURE: 1,
+    SensorDeviceClass.VOLTAGE: 2,
+}
+
+
+def _get_pid_precision(device_class: SensorDeviceClass | None) -> int | None:
+    """Determine how many decimals a PID sensor should display.
+
+    Only PIDs with a device class get a precision. There is no sensible
+    blanket default: MOTOR_RPM, HV_AH_CHARGED and the cell-index PIDs carry
+    units Home Assistant has no device class for, and rendering rpm as
+    "0.00" would be worse than leaving it alone.
+
+    Args:
+        device_class: The resolved SensorDeviceClass, if any.
+
+    Returns:
+        A decimal count, or None to leave the value as the device reports it.
+    """
+    if device_class is None:
+        return None
+    return _DEFAULT_PRECISION.get(device_class)
+
+
 def _get_pid_unit(pid_key: str, config_unit: str | None = None) -> str | None:
     """Determine the appropriate unit for a PID sensor.
 
@@ -202,7 +251,7 @@ def _get_pid_state_class(
 DYNAMIC_PID_SENSORS = {}
 
 
-async def async_setup_entry(  # noqa: C901
+async def async_setup_entry(  # noqa: C901, PLR0915
     hass: HomeAssistant,
     config_entry: WiCANConfigEntry,
     async_add_entities: AddEntitiesCallback,
@@ -227,6 +276,7 @@ async def async_setup_entry(  # noqa: C901
         device_class = _normalize_device_class(config.get("class"), unit, pid_key)
         state_class = _get_pid_state_class(unit, device_class)
         icon = _get_pid_icon(pid_key, device_class)
+        precision = _get_pid_precision(device_class)
 
         _LOGGER.debug(
             "Restoring PID sensor %s with unit=%s, device_class=%s, state_class=%s, icon=%s",
@@ -239,6 +289,7 @@ async def async_setup_entry(  # noqa: C901
             device_class=device_class,
             native_unit_of_measurement=unit,
             state_class=state_class,
+            suggested_display_precision=precision,
             icon=icon,
         )
         entity = WiCANPidSensorEntity(config_entry, pid_key, entity_description)
@@ -264,6 +315,7 @@ async def async_setup_entry(  # noqa: C901
                 device_class = _normalize_device_class(config.get("class"), unit, pid_key)
                 state_class = _get_pid_state_class(unit, device_class)
                 icon = _get_pid_icon(pid_key, device_class)
+                precision = _get_pid_precision(device_class)
 
                 _LOGGER.debug(
                     "Creating new PID sensor %s with unit=%s, device_class=%s, state_class=%s, icon=%s",
@@ -276,6 +328,7 @@ async def async_setup_entry(  # noqa: C901
                     device_class=device_class,
                     native_unit_of_measurement=unit,
                     state_class=state_class,
+                    suggested_display_precision=precision,
                     icon=icon,
                 )
                 entity = WiCANPidSensorEntity(config_entry, pid_key, entity_description)

--- a/custom_components/wican/sensor.py
+++ b/custom_components/wican/sensor.py
@@ -8,7 +8,9 @@ from typing import TYPE_CHECKING
 from homeassistant.components.sensor import (
     RestoreSensor,
     SensorDeviceClass,
+    SensorStateClass,
 )
+from homeassistant.components.sensor.const import DEVICE_CLASS_UNITS
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
@@ -21,6 +23,7 @@ from .param_loader import (
     get_param_unit,
     is_valid_class_unit_combo,
     is_valid_device_class,
+    normalize_unit,
 )
 
 if TYPE_CHECKING:
@@ -30,6 +33,16 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 PARALLEL_UPDATES = 0
+
+# Device classes whose state is a label or an instant in time rather than a
+# quantity, so they must never be given a MEASUREMENT state class.
+_NON_NUMERIC_DEVICE_CLASSES: frozenset[SensorDeviceClass] = frozenset(
+    {
+        SensorDeviceClass.DATE,
+        SensorDeviceClass.ENUM,
+        SensorDeviceClass.TIMESTAMP,
+    },
+)
 
 
 def _get_pid_unit(pid_key: str, config_unit: str | None = None) -> str | None:
@@ -41,6 +54,10 @@ def _get_pid_unit(pid_key: str, config_unit: str | None = None) -> str | None:
 
     This ensures consistent units even if device sometimes sends None.
 
+    Both sources are run through normalize_unit(), which drops placeholders
+    ("none", "Encoded") and rewrites firmware spellings HA does not accept
+    ("degC" -> "°C", "volts" -> "V").
+
     Args:
         pid_key: The PID sensor key/name from the device.
         config_unit: Unit from device config (may be None/empty/"none").
@@ -48,16 +65,13 @@ def _get_pid_unit(pid_key: str, config_unit: str | None = None) -> str | None:
     Returns:
         Unit string (e.g., "km/h", "°C") or None if no match.
     """
-    # Normalize "none", empty string, None to actual None
-    if config_unit in ("none", "", None):
-        config_unit = None
-
     # If device provided a valid unit, use it
-    if config_unit is not None:
-        return config_unit
+    unit = normalize_unit(config_unit)
+    if unit is not None:
+        return unit
 
     # Fallback to params.json lookup
-    return get_param_unit(pid_key)
+    return normalize_unit(get_param_unit(pid_key))
 
 
 def _get_pid_icon(
@@ -134,7 +148,55 @@ def _normalize_device_class(
             )
             return None
 
+    # Home Assistant's own table is authoritative and covers every device
+    # class, including the ones _DEVICE_CLASS_VALID_UNITS has no rules for.
+    # The firmware pairs classes with units HA rejects (e.g. gas + "ratio",
+    # volume_storage + "%", or a temperature class with no unit at all);
+    # keeping the class would cost the sensor its unit conversion and its
+    # long-term statistics, so drop the class and keep the raw measurement.
+    if device_class is not None:
+        valid_units = DEVICE_CLASS_UNITS.get(device_class)
+        if valid_units is not None and unit not in valid_units:
+            _LOGGER.debug(
+                "Unit %s is not valid for device_class %s on %s, dropping device_class",
+                unit, device_class, pid_key or "sensor",
+            )
+            return None
+
     return device_class
+
+
+def _get_pid_state_class(
+    unit: str | None,
+    device_class: SensorDeviceClass | None,
+) -> SensorStateClass | None:
+    """Determine the state class for a PID sensor.
+
+    Numeric PIDs need SensorStateClass.MEASUREMENT to be graphed and recorded
+    as long-term statistics. Without it HA treats them as plain text sensors,
+    which is what standard PIDs such as 42-ControlModuleVolt and
+    46-AmbientAirTemp used to look like.
+
+    Non-numeric PIDs (gear, drive mode, the "on"/"off" flags a profile marks as
+    binary) must NOT get a state class: HA raises on a measurement sensor whose
+    state is not numeric.
+
+    Args:
+        unit: The resolved unit of measurement, if any.
+        device_class: The resolved SensorDeviceClass, if any.
+
+    Returns:
+        SensorStateClass.MEASUREMENT for numeric PIDs, otherwise None.
+    """
+    if device_class in _NON_NUMERIC_DEVICE_CLASSES:
+        return None
+
+    # A PID that reports neither a unit nor a device class carries a label,
+    # not a measurement.
+    if device_class is None and unit is None:
+        return None
+
+    return SensorStateClass.MEASUREMENT
 
 
 DYNAMIC_PID_SENSORS = {}
@@ -163,11 +225,12 @@ async def async_setup_entry(  # noqa: C901
         # Use _get_pid_unit with config unit for consistent fallback handling
         unit = _get_pid_unit(pid_key, config.get("unit"))
         device_class = _normalize_device_class(config.get("class"), unit, pid_key)
+        state_class = _get_pid_state_class(unit, device_class)
         icon = _get_pid_icon(pid_key, device_class)
 
         _LOGGER.debug(
-            "Restoring PID sensor %s with unit=%s, device_class=%s, icon=%s",
-            pid_key, unit, device_class, icon,
+            "Restoring PID sensor %s with unit=%s, device_class=%s, state_class=%s, icon=%s",
+            pid_key, unit, device_class, state_class, icon,
         )
 
         entity_description = WiCANSensorEntityDescription(
@@ -175,7 +238,7 @@ async def async_setup_entry(  # noqa: C901
             name=pid_key,
             device_class=device_class,
             native_unit_of_measurement=unit,
-            state_class="measurement",
+            state_class=state_class,
             icon=icon,
         )
         entity = WiCANPidSensorEntity(config_entry, pid_key, entity_description)
@@ -199,11 +262,12 @@ async def async_setup_entry(  # noqa: C901
                 # Use _get_pid_unit with config unit for consistent fallback handling
                 unit = _get_pid_unit(pid_key, config.get("unit"))
                 device_class = _normalize_device_class(config.get("class"), unit, pid_key)
+                state_class = _get_pid_state_class(unit, device_class)
                 icon = _get_pid_icon(pid_key, device_class)
 
                 _LOGGER.debug(
-                    "Creating new PID sensor %s with unit=%s, device_class=%s, icon=%s",
-                    pid_key, unit, device_class, icon,
+                    "Creating new PID sensor %s with unit=%s, device_class=%s, state_class=%s, icon=%s",
+                    pid_key, unit, device_class, state_class, icon,
                 )
 
                 entity_description = WiCANSensorEntityDescription(
@@ -211,6 +275,7 @@ async def async_setup_entry(  # noqa: C901
                     name=pid_key,
                     device_class=device_class,
                     native_unit_of_measurement=unit,
+                    state_class=state_class,
                     icon=icon,
                 )
                 entity = WiCANPidSensorEntity(config_entry, pid_key, entity_description)

--- a/tests/test_param_loader.py
+++ b/tests/test_param_loader.py
@@ -13,8 +13,62 @@ from custom_components.wican.param_loader import (
     get_all_params,
      is_valid_device_class,
     is_valid_class_unit_combo,
+    normalize_unit,
     DEFAULT_PARAM_ICON,
 )
+
+
+class TestNormalizeUnit:
+    """Tests for normalize_unit function."""
+
+    def test_firmware_temperature_spelling(self) -> None:
+        """Firmware reports degC/degF, HA only accepts the degree-sign form."""
+        assert normalize_unit("degC") == "°C"
+        assert normalize_unit("degF") == "°F"
+        assert normalize_unit("degK") == "K"
+
+    def test_firmware_electrical_spellings(self) -> None:
+        """obd2_standard_pids.h uses "volts" for 16 PIDs."""
+        assert normalize_unit("volts") == "V"
+        assert normalize_unit("amps") == "A"
+        assert normalize_unit("watts") == "W"
+
+    def test_firmware_time_spellings(self) -> None:
+        """Duration PIDs report seconds/minutes/hours."""
+        assert normalize_unit("seconds") == "s"
+        assert normalize_unit("minutes") == "min"
+        assert normalize_unit("hours") == "h"
+
+    def test_case_insensitive(self) -> None:
+        """params.json spells the same unit several ways."""
+        assert normalize_unit("KPa") == "kPa"
+        assert normalize_unit("kPa") == "kPa"
+        assert normalize_unit("RPM") == "rpm"
+        assert normalize_unit("VOLTS") == "V"
+
+    def test_placeholders_become_none(self) -> None:
+        """Placeholders are not units and must not reach HA as one."""
+        for placeholder in ("none", "None", "", "  ", "Encoded", "n/a", "-"):
+            assert normalize_unit(placeholder) is None, placeholder
+
+    def test_none_input(self) -> None:
+        """None passes through as None."""
+        assert normalize_unit(None) is None
+
+    def test_already_valid_units_unchanged(self) -> None:
+        """Units HA already accepts are returned untouched."""
+        for unit in ("°C", "V", "A", "km/h", "%", "kWh", "min", "mA"):
+            assert normalize_unit(unit) == unit, unit
+
+    def test_unknown_units_pass_through(self) -> None:
+        """Custom units are preserved so bespoke PIDs still report a unit."""
+        for unit in ("Nm", "mg/stroke", "kOhm", "L/h", "count"):
+            assert normalize_unit(unit) == unit, unit
+
+    def test_whitespace_stripped(self) -> None:
+        """Surrounding whitespace is trimmed."""
+        assert normalize_unit("  degC  ") == "°C"
+        assert normalize_unit(" km/h ") == "km/h"
 
 
 class TestGetParamUnit:

--- a/tests/test_pid_sensor_config.py
+++ b/tests/test_pid_sensor_config.py
@@ -430,7 +430,7 @@ async def test_pid_sensor_real_world_data_format(
     assert rpm_entity is not None
     rpm_state = hass.states.get("sensor.wican_device_engine_rpm")
     assert rpm_state.state == "4300"
-    assert rpm_state.attributes.get("unit_of_measurement") == "RPM"
+    assert rpm_state.attributes.get("unit_of_measurement") == "rpm"
     # Note: "frequency" class should be normalized to None or valid HA device class
     
     # SPEED sensor
@@ -1016,3 +1016,189 @@ async def test_pid_sensor_invalid_device_class_unit_combo_filtered(
         # Device class "temperature" should be filtered because bananas is not valid
         assert test_state.attributes.get("device_class") is None
 
+
+
+async def test_standard_pid_sensors_are_measurements(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Standard PIDs restored from the config entry report as measurements.
+
+    42-ControlModuleVolt and 46-AmbientAirTemp are the two standard Mode 01
+    PIDs the WiCAN firmware exposes for 12V supply voltage and outside
+    temperature. The firmware spells the ambient unit "degC", which Home
+    Assistant does not accept for the temperature device class.
+    """
+    entry_data = mock_config_entry.data.copy()
+    entry_data["pid_keys"] = ["42-ControlModuleVolt", "46-AmbientAirTemp"]
+    entry_data["config"] = {
+        "42-ControlModuleVolt": {"unit": "V", "class": "voltage"},
+        "46-AmbientAirTemp": {"unit": "degC", "class": "temperature"},
+    }
+    mock_config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="WiCAN Device",
+        data=entry_data,
+        options=mock_config_entry.options,
+        unique_id=mock_config_entry.unique_id,
+    )
+    mock_config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.wican.async_get_clientsession",
+    ), patch(
+        "custom_components.wican.WiCANDataUpdateCoordinator.async_config_entry_first_refresh",
+    ):
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    volt_state = hass.states.get("sensor.wican_device_42_controlmodulevolt")
+    assert volt_state is not None
+    assert volt_state.attributes.get("state_class") == "measurement"
+    assert volt_state.attributes.get("device_class") == "voltage"
+    assert volt_state.attributes.get("unit_of_measurement") == "V"
+
+    temp_state = hass.states.get("sensor.wican_device_46_ambientairtemp")
+    assert temp_state is not None
+    assert temp_state.attributes.get("state_class") == "measurement"
+    assert temp_state.attributes.get("device_class") == "temperature"
+    # "degC" is rewritten to the unit HA accepts for the temperature class
+    assert temp_state.attributes.get("unit_of_measurement") == "°C"
+
+
+async def test_pid_sensor_created_from_webhook_is_a_measurement(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """A PID discovered from a webhook gets the same state class as a restored one.
+
+    Regression test: the discovery path used to omit state_class entirely, so
+    a PID looked like a text sensor until Home Assistant was restarted and the
+    restore path recreated it.
+    """
+    mock_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    webhook_data = {
+        "autopid_data": {"42-ControlModuleVolt": 12.6, "46-AmbientAirTemp": 21},
+        "config": {
+            "42-ControlModuleVolt": {"unit": "V", "class": "voltage"},
+            "46-AmbientAirTemp": {"unit": "degC", "class": "temperature"},
+        },
+    }
+
+    coordinator = mock_config_entry.runtime_data.coordinator
+    coordinator.handle_webhook_data(webhook_data)
+    async_dispatcher_send(hass, "wican", "test_webhook_id", webhook_data)
+    await hass.async_block_till_done()
+    await coordinator.async_request_refresh()
+    await hass.async_block_till_done()
+
+    volt_state = hass.states.get("sensor.wican_device_42_controlmodulevolt")
+    assert volt_state is not None
+    assert volt_state.attributes.get("state_class") == "measurement"
+    assert volt_state.attributes.get("device_class") == "voltage"
+    assert volt_state.state == "12.6"
+
+    temp_state = hass.states.get("sensor.wican_device_46_ambientairtemp")
+    assert temp_state is not None
+    assert temp_state.attributes.get("state_class") == "measurement"
+    assert temp_state.attributes.get("unit_of_measurement") == "°C"
+
+
+async def test_text_pid_sensor_has_no_state_class(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """PIDs with neither a unit nor a device class must not be measurements.
+
+    Vehicle profiles mark flags such as CHARGING and AC_PLUG as binary and send
+    them with unit "" and class "none"; HA raises if a measurement sensor
+    reports a non-numeric state.
+    """
+    entry_data = mock_config_entry.data.copy()
+    entry_data["pid_keys"] = ["AC_PLUG", "41-MonStatusDriveCycle"]
+    entry_data["config"] = {
+        "AC_PLUG": {"unit": "", "class": "none"},
+        # Bitfield PIDs report the placeholder unit "Encoded"
+        "41-MonStatusDriveCycle": {"unit": "Encoded", "class": "none"},
+    }
+    mock_config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="WiCAN Device",
+        data=entry_data,
+        options=mock_config_entry.options,
+        unique_id=mock_config_entry.unique_id,
+    )
+    mock_config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.wican.async_get_clientsession",
+    ), patch(
+        "custom_components.wican.WiCANDataUpdateCoordinator.async_config_entry_first_refresh",
+    ):
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    for entity_id in (
+        "sensor.wican_device_ac_plug",
+        "sensor.wican_device_41_monstatusdrivecycle",
+    ):
+        state = hass.states.get(entity_id)
+        assert state is not None, entity_id
+        assert state.attributes.get("state_class") is None, entity_id
+        assert state.attributes.get("unit_of_measurement") is None, entity_id
+
+
+async def test_device_class_dropped_when_ha_rejects_the_unit(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Classes HA cannot pair with the reported unit are dropped, not passed on.
+
+    The firmware pairs gas with "ratio" and volume_storage with "%", and
+    declares a device class on PIDs that report no unit at all. Keeping the
+    class would cost the sensor its unit conversion and long-term statistics.
+    """
+    entry_data = mock_config_entry.data.copy()
+    entry_data["pid_keys"] = ["24-O2S1WRLambda", "2F-FuelLevel", "3C-CatTempB1S1"]
+    entry_data["config"] = {
+        "24-O2S1WRLambda": {"unit": "ratio", "class": "gas"},
+        "2F-FuelLevel": {"unit": "%", "class": "volume_storage"},
+        "3C-CatTempB1S1": {"unit": "none", "class": "temperature"},
+    }
+    mock_config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="WiCAN Device",
+        data=entry_data,
+        options=mock_config_entry.options,
+        unique_id=mock_config_entry.unique_id,
+    )
+    mock_config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.wican.async_get_clientsession",
+    ), patch(
+        "custom_components.wican.WiCANDataUpdateCoordinator.async_config_entry_first_refresh",
+    ):
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    lambda_state = hass.states.get("sensor.wican_device_24_o2s1wrlambda")
+    assert lambda_state is not None
+    assert lambda_state.attributes.get("device_class") is None
+    assert lambda_state.attributes.get("unit_of_measurement") == "ratio"
+    assert lambda_state.attributes.get("state_class") == "measurement"
+
+    fuel_state = hass.states.get("sensor.wican_device_2f_fuellevel")
+    assert fuel_state is not None
+    assert fuel_state.attributes.get("device_class") is None
+    assert fuel_state.attributes.get("unit_of_measurement") == "%"
+
+    # Device class declared but no unit reported: HA accepts neither pairing
+    cat_state = hass.states.get("sensor.wican_device_3c_cattempb1s1")
+    assert cat_state is not None
+    assert cat_state.attributes.get("device_class") is None
+    assert cat_state.attributes.get("unit_of_measurement") is None

--- a/tests/test_pid_sensor_config.py
+++ b/tests/test_pid_sensor_config.py
@@ -1202,3 +1202,55 @@ async def test_device_class_dropped_when_ha_rejects_the_unit(
     assert cat_state is not None
     assert cat_state.attributes.get("device_class") is None
     assert cat_state.attributes.get("unit_of_measurement") is None
+
+
+async def test_pid_sensors_get_display_precision(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """PIDs with a device class get a sensible number of decimals.
+
+    Without one HA renders whatever the device sends: ODOMETER came through
+    as 50339.1443967231 after the km->mi conversion, while HV_V arrived as
+    345 with no decimals because the firmware's JSON drops the fraction on
+    integral values.
+    """
+    entry_data = mock_config_entry.data.copy()
+    entry_data["pid_keys"] = ["ODOMETER", "HV_V", "BATT_TEMP", "MOTOR_RPM"]
+    entry_data["config"] = {
+        "ODOMETER": {"unit": "km", "class": "distance"},
+        "HV_V": {"unit": "V", "class": "voltage"},
+        "BATT_TEMP": {"unit": "°C", "class": "temperature"},
+        # rpm has no HA device class, so no precision should be invented
+        "MOTOR_RPM": {"unit": "rpm", "class": "speed"},
+    }
+    mock_config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="WiCAN Device",
+        data=entry_data,
+        options=mock_config_entry.options,
+        unique_id=mock_config_entry.unique_id,
+    )
+    mock_config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.wican.async_get_clientsession",
+    ), patch(
+        "custom_components.wican.WiCANDataUpdateCoordinator.async_config_entry_first_refresh",
+    ):
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    entity_registry = er.async_get(hass)
+
+    def precision(entity_id: str) -> int | None:
+        entry = entity_registry.async_get(entity_id)
+        assert entry is not None, entity_id
+        return entry.options.get("sensor", {}).get("suggested_display_precision")
+
+    assert precision("sensor.wican_device_odometer") == 1
+    # Two decimals so per-cell voltage differences stay visible
+    assert precision("sensor.wican_device_hv_v") == 2
+    assert precision("sensor.wican_device_batt_temp") == 1
+    # No device class resolved (speed does not accept rpm), so no precision
+    assert precision("sensor.wican_device_motor_rpm") is None


### PR DESCRIPTION
Nothing set suggested_display_precision.

Add a per-device-class default. This is display only: HA converts and
records the native value, and _update_suggested_precision() rescales the
setting automatically when the unit is converted, so a value stored in km
still reads sensibly in miles.

Voltage gets two decimals rather than one so per-cell differences stay
visible - at one decimal every HV_C_V_nnn reads 3.9 and the cell delta
disappears. The cost is a pack voltage rendering as 345.00, which is the
better trade.

Sensors with no device class are left alone deliberately. There is no
blanket default that works: MOTOR_RPM, HV_AH_CHARGED and the cell-index
PIDs use units HA has no device class for, and showing rpm as "0.00"
would be worse than showing it as the device reports it.

Depends on https://github.com/jay-oswald/ha-wican/pull/83