### PR TITLE
Pick a state class the device class actually permits

### DIFF
--- a/custom_components/wican/param_loader.py
+++ b/custom_components/wican/param_loader.py
@@ -169,6 +169,78 @@ PARAM_NAME_ICONS: Final[dict[str, str]] = {
 DEFAULT_PARAM_ICON: Final[str] = "mdi:car-info"
 
 
+# Placeholder strings the firmware uses in the "unit" field to mean
+# "this value has no unit". "Encoded" is used by the 16 standard PIDs that
+# report packed bitfields (PIDsSupported, MonitorStatus, FuelSysStat, ...).
+_NON_UNITS: Final[frozenset[str]] = frozenset({"", "-", "encoded", "n/a", "none"})
+
+# Unit spellings used by the WiCAN firmware and by the upstream params.json
+# that Home Assistant does not recognise, mapped to the spelling HA expects.
+#
+# HA validates native_unit_of_measurement against the sensor's device class, so
+# a sensor reporting "degC" for a temperature device class loses its unit
+# conversion and its long-term statistics. obd2_standard_pids.h alone uses
+# "degC" for 13 PIDs (including 46-AmbientAirTemp), "volts" for 16 PIDs, and
+# "seconds"/"minutes"/"hours" for the duration PIDs.
+#
+# Keys are lower-cased; anything not listed here is passed through untouched.
+_UNIT_ALIASES: Final[dict[str, str]] = {
+    # Temperature
+    "degc": "°C",
+    "degf": "°F",
+    "degk": "K",
+    # Electrical
+    "volts": "V",
+    "volt": "V",
+    "millivolts": "mV",
+    "amps": "A",
+    "amp": "A",
+    "milliamps": "mA",
+    "watts": "W",
+    "watt": "W",
+    "kilowatts": "kW",
+    # Time
+    "seconds": "s",
+    "sec": "s",
+    "minutes": "min",
+    "mins": "min",
+    "hours": "h",
+    "hour": "h",
+    # Pressure (params.json spells kPa both "kPa" and "KPa")
+    "kpa": "kPa",
+    "hpa": "hPa",
+    # Flow rate
+    "grams/sec": "g/s",
+    # Speed
+    "kph": "km/h",
+    "km/hr": "km/h",
+    # Rotational speed (params.json spells it both "rpm" and "RPM")
+    "rpm": "rpm",
+}
+
+
+def normalize_unit(unit: str | None) -> str | None:
+    """Map a firmware unit string onto the spelling Home Assistant expects.
+
+    Args:
+        unit: Raw unit string from the device config or params.json.
+
+    Returns:
+        The canonical HA unit, or None when the string is a placeholder rather
+        than a real unit. Unrecognised units are returned stripped but
+        otherwise unchanged, so custom units still reach HA.
+    """
+    if unit is None:
+        return None
+
+    stripped = unit.strip()
+    lowered = stripped.lower()
+    if lowered in _NON_UNITS:
+        return None
+
+    return _UNIT_ALIASES.get(lowered, stripped)
+
+
 def _get_params_file_path() -> Path:
     """Get the path to the params.json file."""
     return Path(__file__).parent / "data" / "params.json"

--- a/custom_components/wican/param_loader.py
+++ b/custom_components/wican/param_loader.py
@@ -713,6 +713,39 @@ def get_param_device_class(param_name: str) -> str | None:
     return None
 
 
+# Params that report a monotonically increasing lifetime total rather than an
+# instantaneous measurement. HA's "total_increasing" state class is built for
+# exactly this shape of data: a decrease is treated as the start of a new
+# accumulation cycle (e.g. an odometer rollover, or DIST_SINCE_FULL_CHARGE
+# resetting to 0 at every full charge) rather than graphed as a drop.
+_LIFETIME_COUNTER_PIDS: Final[frozenset[str]] = frozenset(
+    {
+        "KWH_CHARGED",
+        "KWH_DISCHARGED",
+        "HV_AH_CHARGED",
+        "HV_AH_DISCHARGED",
+        "ODOMETER",
+        "ODOMETER_MI",
+        "DIST_SINCE_FULL_CHARGE",
+    },
+)
+
+
+def get_param_state_class(param_name: str) -> str | None:
+    """Get the suggested state class for a parameter, if it is a known lifetime counter.
+
+    Args:
+        param_name: Parameter name (case-insensitive, supports various formats).
+
+    Returns:
+        "total_increasing" for known lifetime counters, None otherwise.
+    """
+    key = _normalize_param_name(param_name)
+    if key in _LIFETIME_COUNTER_PIDS:
+        return "total_increasing"
+    return None
+
+
 def get_param_icon(param_name: str, device_class: str | None = None) -> str:
     """Get the icon for a parameter.
 

--- a/custom_components/wican/param_loader.py
+++ b/custom_components/wican/param_loader.py
@@ -727,6 +727,12 @@ _LIFETIME_COUNTER_PIDS: Final[frozenset[str]] = frozenset(
         "ODOMETER",
         "ODOMETER_MI",
         "DIST_SINCE_FULL_CHARGE",
+        # Cumulative seconds the HV battery has spent at 100 % SoC, reported in
+        # days. Like the others it only ever grows, and the useful signal is how
+        # fast - "days added at 100 % this week" is a direct measure of how often
+        # the car is left sitting topped up. As a measurement it would be graphed
+        # as a flat line a few thousandths of a day higher each week.
+        "TIME_AT_100_SOC",
     },
 )
 

--- a/custom_components/wican/sensor.py
+++ b/custom_components/wican/sensor.py
@@ -8,7 +8,9 @@ from typing import TYPE_CHECKING
 from homeassistant.components.sensor import (
     RestoreSensor,
     SensorDeviceClass,
+    SensorStateClass,
 )
+from homeassistant.components.sensor.const import DEVICE_CLASS_UNITS
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
@@ -21,6 +23,7 @@ from .param_loader import (
     get_param_unit,
     is_valid_class_unit_combo,
     is_valid_device_class,
+    normalize_unit,
 )
 
 if TYPE_CHECKING:
@@ -30,6 +33,16 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 PARALLEL_UPDATES = 0
+
+# Device classes whose state is a label or an instant in time rather than a
+# quantity, so they must never be given a MEASUREMENT state class.
+_NON_NUMERIC_DEVICE_CLASSES: frozenset[SensorDeviceClass] = frozenset(
+    {
+        SensorDeviceClass.DATE,
+        SensorDeviceClass.ENUM,
+        SensorDeviceClass.TIMESTAMP,
+    },
+)
 
 
 def _get_pid_unit(pid_key: str, config_unit: str | None = None) -> str | None:
@@ -41,6 +54,10 @@ def _get_pid_unit(pid_key: str, config_unit: str | None = None) -> str | None:
 
     This ensures consistent units even if device sometimes sends None.
 
+    Both sources are run through normalize_unit(), which drops placeholders
+    ("none", "Encoded") and rewrites firmware spellings HA does not accept
+    ("degC" -> "°C", "volts" -> "V").
+
     Args:
         pid_key: The PID sensor key/name from the device.
         config_unit: Unit from device config (may be None/empty/"none").
@@ -48,16 +65,13 @@ def _get_pid_unit(pid_key: str, config_unit: str | None = None) -> str | None:
     Returns:
         Unit string (e.g., "km/h", "°C") or None if no match.
     """
-    # Normalize "none", empty string, None to actual None
-    if config_unit in ("none", "", None):
-        config_unit = None
-
     # If device provided a valid unit, use it
-    if config_unit is not None:
-        return config_unit
+    unit = normalize_unit(config_unit)
+    if unit is not None:
+        return unit
 
     # Fallback to params.json lookup
-    return get_param_unit(pid_key)
+    return normalize_unit(get_param_unit(pid_key))
 
 
 def _get_pid_icon(
@@ -134,7 +148,55 @@ def _normalize_device_class(
             )
             return None
 
+    # Home Assistant's own table is authoritative and covers every device
+    # class, including the ones _DEVICE_CLASS_VALID_UNITS has no rules for.
+    # The firmware pairs classes with units HA rejects (e.g. gas + "ratio",
+    # volume_storage + "%", or a temperature class with no unit at all);
+    # keeping the class would cost the sensor its unit conversion and its
+    # long-term statistics, so drop the class and keep the raw measurement.
+    if device_class is not None:
+        valid_units = DEVICE_CLASS_UNITS.get(device_class)
+        if valid_units is not None and unit not in valid_units:
+            _LOGGER.debug(
+                "Unit %s is not valid for device_class %s on %s, dropping device_class",
+                unit, device_class, pid_key or "sensor",
+            )
+            return None
+
     return device_class
+
+
+def _get_pid_state_class(
+    unit: str | None,
+    device_class: SensorDeviceClass | None,
+) -> SensorStateClass | None:
+    """Determine the state class for a PID sensor.
+
+    Numeric PIDs need SensorStateClass.MEASUREMENT to be graphed and recorded
+    as long-term statistics. Without it HA treats them as plain text sensors,
+    which is what standard PIDs such as 42-ControlModuleVolt and
+    46-AmbientAirTemp used to look like.
+
+    Non-numeric PIDs (gear, drive mode, the "on"/"off" flags a profile marks as
+    binary) must NOT get a state class: HA raises on a measurement sensor whose
+    state is not numeric.
+
+    Args:
+        unit: The resolved unit of measurement, if any.
+        device_class: The resolved SensorDeviceClass, if any.
+
+    Returns:
+        SensorStateClass.MEASUREMENT for numeric PIDs, otherwise None.
+    """
+    if device_class in _NON_NUMERIC_DEVICE_CLASSES:
+        return None
+
+    # A PID that reports neither a unit nor a device class carries a label,
+    # not a measurement.
+    if device_class is None and unit is None:
+        return None
+
+    return SensorStateClass.MEASUREMENT
 
 
 DYNAMIC_PID_SENSORS = {}
@@ -163,11 +225,12 @@ async def async_setup_entry(  # noqa: C901
         # Use _get_pid_unit with config unit for consistent fallback handling
         unit = _get_pid_unit(pid_key, config.get("unit"))
         device_class = _normalize_device_class(config.get("class"), unit, pid_key)
+        state_class = _get_pid_state_class(unit, device_class)
         icon = _get_pid_icon(pid_key, device_class)
 
         _LOGGER.debug(
-            "Restoring PID sensor %s with unit=%s, device_class=%s, icon=%s",
-            pid_key, unit, device_class, icon,
+            "Restoring PID sensor %s with unit=%s, device_class=%s, state_class=%s, icon=%s",
+            pid_key, unit, device_class, state_class, icon,
         )
 
         entity_description = WiCANSensorEntityDescription(
@@ -175,7 +238,7 @@ async def async_setup_entry(  # noqa: C901
             name=pid_key,
             device_class=device_class,
             native_unit_of_measurement=unit,
-            state_class="measurement",
+            state_class=state_class,
             icon=icon,
         )
         entity = WiCANPidSensorEntity(config_entry, pid_key, entity_description)
@@ -199,11 +262,12 @@ async def async_setup_entry(  # noqa: C901
                 # Use _get_pid_unit with config unit for consistent fallback handling
                 unit = _get_pid_unit(pid_key, config.get("unit"))
                 device_class = _normalize_device_class(config.get("class"), unit, pid_key)
+                state_class = _get_pid_state_class(unit, device_class)
                 icon = _get_pid_icon(pid_key, device_class)
 
                 _LOGGER.debug(
-                    "Creating new PID sensor %s with unit=%s, device_class=%s, icon=%s",
-                    pid_key, unit, device_class, icon,
+                    "Creating new PID sensor %s with unit=%s, device_class=%s, state_class=%s, icon=%s",
+                    pid_key, unit, device_class, state_class, icon,
                 )
 
                 entity_description = WiCANSensorEntityDescription(
@@ -211,6 +275,7 @@ async def async_setup_entry(  # noqa: C901
                     name=pid_key,
                     device_class=device_class,
                     native_unit_of_measurement=unit,
+                    state_class=state_class,
                     icon=icon,
                 )
                 entity = WiCANPidSensorEntity(config_entry, pid_key, entity_description)

--- a/custom_components/wican/sensor.py
+++ b/custom_components/wican/sensor.py
@@ -10,7 +10,10 @@ from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorStateClass,
 )
-from homeassistant.components.sensor.const import DEVICE_CLASS_UNITS
+from homeassistant.components.sensor.const import (
+    DEVICE_CLASS_STATE_CLASSES,
+    DEVICE_CLASS_UNITS,
+)
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
@@ -20,6 +23,7 @@ from .entity import WiCANEntity
 from .param_loader import (
     get_param_device_class,
     get_param_icon,
+    get_param_state_class,
     get_param_unit,
     is_valid_class_unit_combo,
     is_valid_device_class,
@@ -34,14 +38,15 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 PARALLEL_UPDATES = 0
 
-# Device classes whose state is a label or an instant in time rather than a
-# quantity, so they must never be given a MEASUREMENT state class.
-_NON_NUMERIC_DEVICE_CLASSES: frozenset[SensorDeviceClass] = frozenset(
-    {
-        SensorDeviceClass.DATE,
-        SensorDeviceClass.ENUM,
-        SensorDeviceClass.TIMESTAMP,
-    },
+# Params classed "energy" upstream that are actually a capacity or a
+# remaining-charge level, not a cumulative counter. HA's "energy" device
+# class permits only "total"/"total_increasing" state classes (see
+# DEVICE_CLASS_STATE_CLASSES) - forcing either onto a level value would
+# report it as ever-accumulating, which it is not. "energy_storage" is the
+# device class for exactly this shape of value and still permits
+# "measurement".
+_ENERGY_LEVEL_PIDS: frozenset[str] = frozenset(
+    {"HV_CAPACITY_KWH", "HV_CAPACITY_R", "HV_KWH_R"},
 )
 
 
@@ -93,7 +98,7 @@ def _get_pid_icon(
     return get_param_icon(pid_key, device_class_str)
 
 
-def _normalize_device_class(
+def _normalize_device_class(  # noqa: C901
     device_class: str | SensorDeviceClass | None,
     unit: str | None,
     pid_key: str | None = None,
@@ -138,6 +143,15 @@ def _normalize_device_class(
             )
             return None
 
+    # A handful of params are classed "energy" upstream but are actually a
+    # capacity/level rather than a cumulative counter - see _ENERGY_LEVEL_PIDS.
+    if (
+        device_class == SensorDeviceClass.ENERGY
+        and pid_key
+        and pid_key.upper() in _ENERGY_LEVEL_PIDS
+    ):
+        device_class = SensorDeviceClass.ENERGY_STORAGE
+
     # Validate class+unit combination
     if device_class is not None and unit is not None:
         dc_str = device_class.value if isinstance(device_class, SensorDeviceClass) else str(device_class)
@@ -166,37 +180,69 @@ def _normalize_device_class(
     return device_class
 
 
-def _get_pid_state_class(
+def _get_pid_state_class(  # noqa: PLR0911
     unit: str | None,
     device_class: SensorDeviceClass | None,
+    pid_key: str | None = None,
 ) -> SensorStateClass | None:
     """Determine the state class for a PID sensor.
 
-    Numeric PIDs need SensorStateClass.MEASUREMENT to be graphed and recorded
-    as long-term statistics. Without it HA treats them as plain text sensors,
-    which is what standard PIDs such as 42-ControlModuleVolt and
-    46-AmbientAirTemp used to look like.
+    Numeric PIDs need a state class to be graphed and recorded as long-term
+    statistics. Without one HA treats them as plain text sensors, which is
+    what standard PIDs such as 42-ControlModuleVolt and 46-AmbientAirTemp
+    used to look like.
 
-    Non-numeric PIDs (gear, drive mode, the "on"/"off" flags a profile marks as
-    binary) must NOT get a state class: HA raises on a measurement sensor whose
-    state is not numeric.
+    Which state class depends on the device class: HA restricts each device
+    class to a specific set via DEVICE_CLASS_STATE_CLASSES. "energy" for
+    example permits only "total"/"total_increasing", never "measurement" -
+    passing "measurement" regardless is what made KWH_CHARGED and
+    KWH_DISCHARGED fail HA's validation ("using state class 'measurement'
+    which is impossible considering device class ('energy')").
+
+    Non-numeric PIDs (gear, drive mode, the flags a profile marks as binary)
+    must NOT get a state class: HA raises on a measurement sensor whose state
+    is not numeric.
 
     Args:
         unit: The resolved unit of measurement, if any.
         device_class: The resolved SensorDeviceClass, if any.
+        pid_key: PID key, used to look up whether this is a known lifetime
+            counter (get_param_state_class()) that should prefer
+            "total_increasing" over "measurement" when both are permitted.
 
     Returns:
-        SensorStateClass.MEASUREMENT for numeric PIDs, otherwise None.
+        The best SensorStateClass for this PID: None when the device class
+        permits none (DATE/ENUM/TIMESTAMP) or when the PID carries no unit
+        and no device class at all, otherwise the preferred state class the
+        device class allows.
     """
-    if device_class in _NON_NUMERIC_DEVICE_CLASSES:
-        return None
-
     # A PID that reports neither a unit nor a device class carries a label,
     # not a measurement.
     if device_class is None and unit is None:
         return None
 
-    return SensorStateClass.MEASUREMENT
+    hint: SensorStateClass | None = None
+    if pid_key and get_param_state_class(pid_key) == "total_increasing":
+        hint = SensorStateClass.TOTAL_INCREASING
+
+    if device_class is None:
+        return hint or SensorStateClass.MEASUREMENT
+
+    allowed = DEVICE_CLASS_STATE_CLASSES.get(device_class)
+    if allowed is None:
+        # Not in HA's table - shouldn't happen, since it covers every device
+        # class _normalize_device_class() can return. Fall back to the
+        # historical behaviour rather than silently dropping the state class.
+        return SensorStateClass.MEASUREMENT
+    if not allowed:
+        return None
+    if hint is not None and hint in allowed:
+        return hint
+    if SensorStateClass.MEASUREMENT in allowed:
+        return SensorStateClass.MEASUREMENT
+    if SensorStateClass.TOTAL_INCREASING in allowed:
+        return SensorStateClass.TOTAL_INCREASING
+    return SensorStateClass.TOTAL
 
 
 DYNAMIC_PID_SENSORS = {}
@@ -225,7 +271,7 @@ async def async_setup_entry(  # noqa: C901
         # Use _get_pid_unit with config unit for consistent fallback handling
         unit = _get_pid_unit(pid_key, config.get("unit"))
         device_class = _normalize_device_class(config.get("class"), unit, pid_key)
-        state_class = _get_pid_state_class(unit, device_class)
+        state_class = _get_pid_state_class(unit, device_class, pid_key)
         icon = _get_pid_icon(pid_key, device_class)
 
         _LOGGER.debug(
@@ -262,7 +308,7 @@ async def async_setup_entry(  # noqa: C901
                 # Use _get_pid_unit with config unit for consistent fallback handling
                 unit = _get_pid_unit(pid_key, config.get("unit"))
                 device_class = _normalize_device_class(config.get("class"), unit, pid_key)
-                state_class = _get_pid_state_class(unit, device_class)
+                state_class = _get_pid_state_class(unit, device_class, pid_key)
                 icon = _get_pid_icon(pid_key, device_class)
 
                 _LOGGER.debug(

--- a/tests/test_param_loader.py
+++ b/tests/test_param_loader.py
@@ -13,8 +13,62 @@ from custom_components.wican.param_loader import (
     get_all_params,
      is_valid_device_class,
     is_valid_class_unit_combo,
+    normalize_unit,
     DEFAULT_PARAM_ICON,
 )
+
+
+class TestNormalizeUnit:
+    """Tests for normalize_unit function."""
+
+    def test_firmware_temperature_spelling(self) -> None:
+        """Firmware reports degC/degF, HA only accepts the degree-sign form."""
+        assert normalize_unit("degC") == "°C"
+        assert normalize_unit("degF") == "°F"
+        assert normalize_unit("degK") == "K"
+
+    def test_firmware_electrical_spellings(self) -> None:
+        """obd2_standard_pids.h uses "volts" for 16 PIDs."""
+        assert normalize_unit("volts") == "V"
+        assert normalize_unit("amps") == "A"
+        assert normalize_unit("watts") == "W"
+
+    def test_firmware_time_spellings(self) -> None:
+        """Duration PIDs report seconds/minutes/hours."""
+        assert normalize_unit("seconds") == "s"
+        assert normalize_unit("minutes") == "min"
+        assert normalize_unit("hours") == "h"
+
+    def test_case_insensitive(self) -> None:
+        """params.json spells the same unit several ways."""
+        assert normalize_unit("KPa") == "kPa"
+        assert normalize_unit("kPa") == "kPa"
+        assert normalize_unit("RPM") == "rpm"
+        assert normalize_unit("VOLTS") == "V"
+
+    def test_placeholders_become_none(self) -> None:
+        """Placeholders are not units and must not reach HA as one."""
+        for placeholder in ("none", "None", "", "  ", "Encoded", "n/a", "-"):
+            assert normalize_unit(placeholder) is None, placeholder
+
+    def test_none_input(self) -> None:
+        """None passes through as None."""
+        assert normalize_unit(None) is None
+
+    def test_already_valid_units_unchanged(self) -> None:
+        """Units HA already accepts are returned untouched."""
+        for unit in ("°C", "V", "A", "km/h", "%", "kWh", "min", "mA"):
+            assert normalize_unit(unit) == unit, unit
+
+    def test_unknown_units_pass_through(self) -> None:
+        """Custom units are preserved so bespoke PIDs still report a unit."""
+        for unit in ("Nm", "mg/stroke", "kOhm", "L/h", "count"):
+            assert normalize_unit(unit) == unit, unit
+
+    def test_whitespace_stripped(self) -> None:
+        """Surrounding whitespace is trimmed."""
+        assert normalize_unit("  degC  ") == "°C"
+        assert normalize_unit(" km/h ") == "km/h"
 
 
 class TestGetParamUnit:

--- a/tests/test_param_loader.py
+++ b/tests/test_param_loader.py
@@ -8,6 +8,7 @@ from custom_components.wican.param_loader import (
     get_param_unit,
     get_param_device_class,
     get_param_icon,
+    get_param_state_class,
     get_param_description,
     is_binary_sensor,
     get_all_params,
@@ -521,3 +522,32 @@ class TestGitHubParamsUpdate:
         params = get_all_params()
         assert isinstance(params, dict)
         assert "SOC" in params  # Known param should still exist
+
+class TestGetParamStateClass:
+    """Tests for get_param_state_class function."""
+
+    def test_lifetime_counters(self) -> None:
+        """Cumulative totals are flagged so they can be total_increasing."""
+        for name in (
+            "KWH_CHARGED",
+            "KWH_DISCHARGED",
+            "HV_AH_CHARGED",
+            "HV_AH_DISCHARGED",
+            "ODOMETER",
+            "DIST_SINCE_FULL_CHARGE",
+        ):
+            assert get_param_state_class(name) == "total_increasing", name
+
+    def test_alias_spellings_resolve(self) -> None:
+        """Alias forms of a counter resolve too."""
+        assert get_param_state_class("a6-odometer") == "total_increasing"
+        assert get_param_state_class("odometer") == "total_increasing"
+
+    def test_instantaneous_params_have_no_hint(self) -> None:
+        """Values that are levels or readings get no hint."""
+        for name in ("SOC", "HV_V", "RANGE", "HV_CAPACITY_KWH", "HV_KWH_R"):
+            assert get_param_state_class(name) is None, name
+
+    def test_unknown_param(self) -> None:
+        """Unknown names get no hint."""
+        assert get_param_state_class("totally_unknown") is None

--- a/tests/test_param_loader.py
+++ b/tests/test_param_loader.py
@@ -535,6 +535,7 @@ class TestGetParamStateClass:
             "HV_AH_DISCHARGED",
             "ODOMETER",
             "DIST_SINCE_FULL_CHARGE",
+            "TIME_AT_100_SOC",
         ):
             assert get_param_state_class(name) == "total_increasing", name
 

--- a/tests/test_pid_sensor_config.py
+++ b/tests/test_pid_sensor_config.py
@@ -430,7 +430,7 @@ async def test_pid_sensor_real_world_data_format(
     assert rpm_entity is not None
     rpm_state = hass.states.get("sensor.wican_device_engine_rpm")
     assert rpm_state.state == "4300"
-    assert rpm_state.attributes.get("unit_of_measurement") == "RPM"
+    assert rpm_state.attributes.get("unit_of_measurement") == "rpm"
     # Note: "frequency" class should be normalized to None or valid HA device class
     
     # SPEED sensor
@@ -1016,3 +1016,189 @@ async def test_pid_sensor_invalid_device_class_unit_combo_filtered(
         # Device class "temperature" should be filtered because bananas is not valid
         assert test_state.attributes.get("device_class") is None
 
+
+
+async def test_standard_pid_sensors_are_measurements(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Standard PIDs restored from the config entry report as measurements.
+
+    42-ControlModuleVolt and 46-AmbientAirTemp are the two standard Mode 01
+    PIDs the WiCAN firmware exposes for 12V supply voltage and outside
+    temperature. The firmware spells the ambient unit "degC", which Home
+    Assistant does not accept for the temperature device class.
+    """
+    entry_data = mock_config_entry.data.copy()
+    entry_data["pid_keys"] = ["42-ControlModuleVolt", "46-AmbientAirTemp"]
+    entry_data["config"] = {
+        "42-ControlModuleVolt": {"unit": "V", "class": "voltage"},
+        "46-AmbientAirTemp": {"unit": "degC", "class": "temperature"},
+    }
+    mock_config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="WiCAN Device",
+        data=entry_data,
+        options=mock_config_entry.options,
+        unique_id=mock_config_entry.unique_id,
+    )
+    mock_config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.wican.async_get_clientsession",
+    ), patch(
+        "custom_components.wican.WiCANDataUpdateCoordinator.async_config_entry_first_refresh",
+    ):
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    volt_state = hass.states.get("sensor.wican_device_42_controlmodulevolt")
+    assert volt_state is not None
+    assert volt_state.attributes.get("state_class") == "measurement"
+    assert volt_state.attributes.get("device_class") == "voltage"
+    assert volt_state.attributes.get("unit_of_measurement") == "V"
+
+    temp_state = hass.states.get("sensor.wican_device_46_ambientairtemp")
+    assert temp_state is not None
+    assert temp_state.attributes.get("state_class") == "measurement"
+    assert temp_state.attributes.get("device_class") == "temperature"
+    # "degC" is rewritten to the unit HA accepts for the temperature class
+    assert temp_state.attributes.get("unit_of_measurement") == "°C"
+
+
+async def test_pid_sensor_created_from_webhook_is_a_measurement(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """A PID discovered from a webhook gets the same state class as a restored one.
+
+    Regression test: the discovery path used to omit state_class entirely, so
+    a PID looked like a text sensor until Home Assistant was restarted and the
+    restore path recreated it.
+    """
+    mock_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    webhook_data = {
+        "autopid_data": {"42-ControlModuleVolt": 12.6, "46-AmbientAirTemp": 21},
+        "config": {
+            "42-ControlModuleVolt": {"unit": "V", "class": "voltage"},
+            "46-AmbientAirTemp": {"unit": "degC", "class": "temperature"},
+        },
+    }
+
+    coordinator = mock_config_entry.runtime_data.coordinator
+    coordinator.handle_webhook_data(webhook_data)
+    async_dispatcher_send(hass, "wican", "test_webhook_id", webhook_data)
+    await hass.async_block_till_done()
+    await coordinator.async_request_refresh()
+    await hass.async_block_till_done()
+
+    volt_state = hass.states.get("sensor.wican_device_42_controlmodulevolt")
+    assert volt_state is not None
+    assert volt_state.attributes.get("state_class") == "measurement"
+    assert volt_state.attributes.get("device_class") == "voltage"
+    assert volt_state.state == "12.6"
+
+    temp_state = hass.states.get("sensor.wican_device_46_ambientairtemp")
+    assert temp_state is not None
+    assert temp_state.attributes.get("state_class") == "measurement"
+    assert temp_state.attributes.get("unit_of_measurement") == "°C"
+
+
+async def test_text_pid_sensor_has_no_state_class(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """PIDs with neither a unit nor a device class must not be measurements.
+
+    Vehicle profiles mark flags such as CHARGING and AC_PLUG as binary and send
+    them with unit "" and class "none"; HA raises if a measurement sensor
+    reports a non-numeric state.
+    """
+    entry_data = mock_config_entry.data.copy()
+    entry_data["pid_keys"] = ["AC_PLUG", "41-MonStatusDriveCycle"]
+    entry_data["config"] = {
+        "AC_PLUG": {"unit": "", "class": "none"},
+        # Bitfield PIDs report the placeholder unit "Encoded"
+        "41-MonStatusDriveCycle": {"unit": "Encoded", "class": "none"},
+    }
+    mock_config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="WiCAN Device",
+        data=entry_data,
+        options=mock_config_entry.options,
+        unique_id=mock_config_entry.unique_id,
+    )
+    mock_config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.wican.async_get_clientsession",
+    ), patch(
+        "custom_components.wican.WiCANDataUpdateCoordinator.async_config_entry_first_refresh",
+    ):
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    for entity_id in (
+        "sensor.wican_device_ac_plug",
+        "sensor.wican_device_41_monstatusdrivecycle",
+    ):
+        state = hass.states.get(entity_id)
+        assert state is not None, entity_id
+        assert state.attributes.get("state_class") is None, entity_id
+        assert state.attributes.get("unit_of_measurement") is None, entity_id
+
+
+async def test_device_class_dropped_when_ha_rejects_the_unit(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Classes HA cannot pair with the reported unit are dropped, not passed on.
+
+    The firmware pairs gas with "ratio" and volume_storage with "%", and
+    declares a device class on PIDs that report no unit at all. Keeping the
+    class would cost the sensor its unit conversion and long-term statistics.
+    """
+    entry_data = mock_config_entry.data.copy()
+    entry_data["pid_keys"] = ["24-O2S1WRLambda", "2F-FuelLevel", "3C-CatTempB1S1"]
+    entry_data["config"] = {
+        "24-O2S1WRLambda": {"unit": "ratio", "class": "gas"},
+        "2F-FuelLevel": {"unit": "%", "class": "volume_storage"},
+        "3C-CatTempB1S1": {"unit": "none", "class": "temperature"},
+    }
+    mock_config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="WiCAN Device",
+        data=entry_data,
+        options=mock_config_entry.options,
+        unique_id=mock_config_entry.unique_id,
+    )
+    mock_config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.wican.async_get_clientsession",
+    ), patch(
+        "custom_components.wican.WiCANDataUpdateCoordinator.async_config_entry_first_refresh",
+    ):
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    lambda_state = hass.states.get("sensor.wican_device_24_o2s1wrlambda")
+    assert lambda_state is not None
+    assert lambda_state.attributes.get("device_class") is None
+    assert lambda_state.attributes.get("unit_of_measurement") == "ratio"
+    assert lambda_state.attributes.get("state_class") == "measurement"
+
+    fuel_state = hass.states.get("sensor.wican_device_2f_fuellevel")
+    assert fuel_state is not None
+    assert fuel_state.attributes.get("device_class") is None
+    assert fuel_state.attributes.get("unit_of_measurement") == "%"
+
+    # Device class declared but no unit reported: HA accepts neither pairing
+    cat_state = hass.states.get("sensor.wican_device_3c_cattempb1s1")
+    assert cat_state is not None
+    assert cat_state.attributes.get("device_class") is None
+    assert cat_state.attributes.get("unit_of_measurement") is None

--- a/tests/test_pid_sensor_config.py
+++ b/tests/test_pid_sensor_config.py
@@ -1202,3 +1202,130 @@ async def test_device_class_dropped_when_ha_rejects_the_unit(
     assert cat_state is not None
     assert cat_state.attributes.get("device_class") is None
     assert cat_state.attributes.get("unit_of_measurement") is None
+
+
+async def test_energy_counters_use_total_increasing(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Cumulative energy PIDs get a state class HA accepts for device_class energy.
+
+    Regression test for the two errors this produced in the log:
+    "using state class 'measurement' which is impossible considering device
+    class ('energy')".
+    """
+    entry_data = mock_config_entry.data.copy()
+    entry_data["pid_keys"] = ["KWH_CHARGED", "KWH_DISCHARGED"]
+    entry_data["config"] = {
+        "KWH_CHARGED": {"unit": "kWh", "class": "energy"},
+        "KWH_DISCHARGED": {"unit": "kWh", "class": "energy"},
+    }
+    mock_config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="WiCAN Device",
+        data=entry_data,
+        options=mock_config_entry.options,
+        unique_id=mock_config_entry.unique_id,
+    )
+    mock_config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.wican.async_get_clientsession",
+    ), patch(
+        "custom_components.wican.WiCANDataUpdateCoordinator.async_config_entry_first_refresh",
+    ):
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    for entity_id in (
+        "sensor.wican_device_kwh_charged",
+        "sensor.wican_device_kwh_discharged",
+    ):
+        state = hass.states.get(entity_id)
+        assert state is not None, entity_id
+        assert state.attributes.get("device_class") == "energy", entity_id
+        assert state.attributes.get("state_class") == "total_increasing", entity_id
+
+
+async def test_energy_levels_use_energy_storage(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Capacity/remaining PIDs are levels, so they keep a measurement state class.
+
+    params.json classes them "energy", which forbids measurement; energy_storage
+    is the device class for a level and permits it.
+    """
+    entry_data = mock_config_entry.data.copy()
+    entry_data["pid_keys"] = ["HV_CAPACITY_KWH", "HV_KWH_R"]
+    entry_data["config"] = {
+        "HV_CAPACITY_KWH": {"unit": "kWh", "class": "energy"},
+        "HV_KWH_R": {"unit": "Wh", "class": "energy"},
+    }
+    mock_config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="WiCAN Device",
+        data=entry_data,
+        options=mock_config_entry.options,
+        unique_id=mock_config_entry.unique_id,
+    )
+    mock_config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.wican.async_get_clientsession",
+    ), patch(
+        "custom_components.wican.WiCANDataUpdateCoordinator.async_config_entry_first_refresh",
+    ):
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    for entity_id in (
+        "sensor.wican_device_hv_capacity_kwh",
+        "sensor.wican_device_hv_kwh_r",
+    ):
+        state = hass.states.get(entity_id)
+        assert state is not None, entity_id
+        assert state.attributes.get("device_class") == "energy_storage", entity_id
+        assert state.attributes.get("state_class") == "measurement", entity_id
+
+
+async def test_odometer_uses_total_increasing(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Lifetime counters get total_increasing even where measurement is allowed.
+
+    distance permits measurement, so HA does not complain, but an odometer's
+    statistics only make sense as an accumulating total.
+    """
+    entry_data = mock_config_entry.data.copy()
+    entry_data["pid_keys"] = ["ODOMETER", "RANGE"]
+    entry_data["config"] = {
+        "ODOMETER": {"unit": "km", "class": "distance"},
+        "RANGE": {"unit": "km", "class": "distance"},
+    }
+    mock_config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="WiCAN Device",
+        data=entry_data,
+        options=mock_config_entry.options,
+        unique_id=mock_config_entry.unique_id,
+    )
+    mock_config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.wican.async_get_clientsession",
+    ), patch(
+        "custom_components.wican.WiCANDataUpdateCoordinator.async_config_entry_first_refresh",
+    ):
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    odo = hass.states.get("sensor.wican_device_odometer")
+    assert odo is not None
+    assert odo.attributes.get("state_class") == "total_increasing"
+
+    # RANGE is an instantaneous reading with the same device class
+    rng = hass.states.get("sensor.wican_device_range")
+    assert rng is not None
+    assert rng.attributes.get("state_class") == "measurement"


### PR DESCRIPTION
Home Assistant rejected two sensors on every startup:

  sensor...kwh_discharged is using state class 'measurement' which is
  impossible considering device class ('energy') it is using; expected
  None or one of 'total', 'total_increasing'

_get_pid_state_class() validated the unit against the device class but
never the state class, and returned MEASUREMENT for anything numeric. HA
restricts each device class to a set of state classes and publishes the
table as DEVICE_CLASS_STATE_CLASSES: energy/gas/volume/water permit only
total and total_increasing, monetary only total, and date/enum/timestamp
none at all.

Validate against that table and pick the first permitted of
hint -> measurement -> total_increasing -> total.

The hint comes from param_loader.get_param_state_class(), which flags the
params that report a monotonic lifetime total rather than a reading:
KWH_CHARGED, KWH_DISCHARGED, HV_AH_CHARGED, HV_AH_DISCHARGED, ODOMETER,
ODOMETER_MI and DIST_SINCE_FULL_CHARGE. Those become total_increasing.
ODOMETER and the HV_AH_* pair were not failing validation - distance
permits measurement - but an odometer's statistics only make sense as an
accumulating total.

A blanket energy -> total_increasing would have been wrong for the other
three params params.json classes as energy: HV_CAPACITY_KWH,
HV_CAPACITY_R and HV_KWH_R are capacities and remaining levels, not
counters. They are remapped to energy_storage, which is the device class
for a level and does permit measurement.

Every param in params.json and every unit/class pair in the firmware's
obd2_standard_pids.h now produces a combination Home Assistant accepts.

Depends on https://github.com/jay-oswald/ha-wican/pull/83