### PR TITLE
Read the unit when params.json says "battery" but means something else

### DIFF
--- a/custom_components/wican/param_loader.py
+++ b/custom_components/wican/param_loader.py
@@ -77,6 +77,8 @@ DEVICE_CLASS_ICONS: Final[dict[str, str]] = {
 PARAM_NAME_ICONS: Final[dict[str, str]] = {
     # Engine
     "engine_rpm": "mdi:engine",
+    "engine_load": "mdi:engine",
+    "timing_adv": "mdi:timer-cog-outline",
     # Fuel
     "fuel": "mdi:fuel",
     "fuel_rate": "mdi:gas-station",
@@ -100,6 +102,7 @@ PARAM_NAME_ICONS: Final[dict[str, str]] = {
     "oilch_dis": "mdi:oil",
     # Battery/Voltage (12V)
     "lv_v": "mdi:car-battery",
+    "ctrl_mod_v": "mdi:car-battery",
     "alt_duty": "mdi:current-ac",
     # EV Battery/SOC
     "soc": "mdi:battery",
@@ -433,6 +436,65 @@ _PID_ALIASES: Final[dict[str, str]] = {
 }
 
 
+# params.json describes vehicle-profile parameters (SOC, HV_V, RANGE, ...), not
+# standard OBD-II Mode 01 PIDs, so six of the names _PID_ALIASES maps to have
+# never existed in it - the lookup silently returned nothing for the PIDs most
+# vehicles actually support. These fill that gap.
+#
+# Units match what obd2_standard_pids.h reports for the same PID, so a sensor
+# built from this fallback and one built from the device's own config agree and
+# HA does not see the unit change underneath it.
+_STANDARD_PID_FALLBACKS: Final[dict[str, ParamDefinition]] = {
+    # PID 0x46
+    "AMBIENT_TMP": {
+        "description": "Ambient Air Temperature",
+        "settings": {"unit": "°C", "class": "temperature"},
+    },
+    # PID 0x33
+    "BARO_PRES": {
+        "description": "Absolute Barometric Pressure",
+        "settings": {"unit": "kPa", "class": "pressure"},
+    },
+    # PID 0x42
+    "CTRL_MOD_V": {
+        "description": "Control Module Voltage",
+        "settings": {"unit": "V", "class": "voltage"},
+    },
+    # PID 0x21
+    "DIST_MIL": {
+        "description": "Distance Travelled With MIL On",
+        "settings": {"unit": "km", "class": "distance"},
+    },
+    # PID 0x04
+    "ENGINE_LOAD": {
+        "description": "Calculated Engine Load",
+        "settings": {"unit": "%", "class": "none"},
+    },
+    # PID 0x0E
+    "TIMING_ADV": {
+        "description": "Timing Advance",
+        "settings": {"unit": "deg", "class": "none"},
+    },
+}
+
+
+def _lookup_param(param_name: str) -> ParamDefinition | None:
+    """Resolve a parameter definition by name.
+
+    params.json wins; the built-in standard-PID table fills the gaps it has.
+
+    Args:
+        param_name: Parameter name (case-insensitive, supports various formats).
+
+    Returns:
+        The parameter definition, or None if the name is unknown.
+    """
+    key = _normalize_param_name(param_name)
+    if key in _PARAMS:
+        return _PARAMS[key]
+    return _STANDARD_PID_FALLBACKS.get(key)
+
+
 # Valid Home Assistant sensor device classes
 # Invalid classes from firmware will be filtered out
 _VALID_HA_DEVICE_CLASSES: Final[set[str]] = {
@@ -609,11 +671,10 @@ def get_param_unit(param_name: str) -> str | None:
     Returns:
         Unit string or None if not found/empty.
     """
-    # Normalize to canonical params.json name
-    key = _normalize_param_name(param_name)
+    param = _lookup_param(param_name)
 
-    if key in _PARAMS:
-        unit = _PARAMS[key].get("settings", {}).get("unit", "")
+    if param is not None:
+        unit = param.get("settings", {}).get("unit", "")
         # Return None for empty/none units
         if unit and unit.lower() not in ("", "none"):
             return unit
@@ -630,10 +691,10 @@ def get_param_device_class(param_name: str) -> str | None:
     Returns:
         Device class string or None if not found/invalid.
     """
-    key = _normalize_param_name(param_name)
+    param = _lookup_param(param_name)
 
-    if key in _PARAMS:
-        device_class = _PARAMS[key].get("settings", {}).get("class", "")
+    if param is not None:
+        device_class = param.get("settings", {}).get("class", "")
         # Return None for empty/none classes
         if device_class and device_class.lower() not in ("", "none"):
             return device_class
@@ -685,10 +746,10 @@ def get_param_description(param_name: str) -> str | None:
     Returns:
         Description string or None if not found.
     """
-    key = _normalize_param_name(param_name)
+    param = _lookup_param(param_name)
 
-    if key in _PARAMS:
-        return _PARAMS[key].get("description")
+    if param is not None:
+        return param.get("description")
 
     return None
 
@@ -702,10 +763,10 @@ def is_binary_sensor(param_name: str) -> bool:
     Returns:
         True if parameter is defined as binary_sensor type.
     """
-    key = _normalize_param_name(param_name)
+    param = _lookup_param(param_name)
 
-    if key in _PARAMS:
-        return _PARAMS[key].get("settings", {}).get("type") == "binary_sensor"
+    if param is not None:
+        return param.get("settings", {}).get("type") == "binary_sensor"
 
     return False
 

--- a/custom_components/wican/param_loader.py
+++ b/custom_components/wican/param_loader.py
@@ -682,6 +682,45 @@ def get_param_unit(param_name: str) -> str | None:
     return None
 
 
+# params.json uses "battery" loosely, to mean "something about the battery",
+# and pairs it with whatever unit the value actually has. Home Assistant's
+# battery device class accepts only "%", so every one of those parameters -
+# 198 of them, including every HV_C_V_nnn cell voltage, LV_V, AC_C_V and
+# CAPACITOR - lost its device class, its unit conversion and its icon.
+#
+# The unit says what the value really is, so use it. Upstream has already
+# corrected a few entries this way (AC_C_C -> current, HV_AV -> power,
+# KWH_CHARGED -> energy); this applies the same reading to the rest.
+_UNIT_TO_DEVICE_CLASS: Final[dict[str, str]] = {
+    "v": "voltage",
+    "mv": "voltage",
+    "kv": "voltage",
+    "a": "current",
+    "ma": "current",
+    "w": "power",
+    "kw": "power",
+    "mw": "power",
+    "wh": "energy_storage",
+    "kwh": "energy_storage",
+    "mwh": "energy_storage",
+}
+
+
+def _infer_device_class_from_unit(unit: str | None) -> str | None:
+    """Infer a device class from a unit, for params.json's overloaded "battery".
+
+    Args:
+        unit: The parameter's unit of measurement.
+
+    Returns:
+        A device class string, or None when the unit does not imply one
+        (e.g. "Ah" - Home Assistant has no electric-charge device class).
+    """
+    if not unit:
+        return None
+    return _UNIT_TO_DEVICE_CLASS.get(unit.strip().lower())
+
+
 def get_param_device_class(param_name: str) -> str | None:
     """Get the device class for a parameter name.
 
@@ -694,9 +733,16 @@ def get_param_device_class(param_name: str) -> str | None:
     param = _lookup_param(param_name)
 
     if param is not None:
-        device_class = param.get("settings", {}).get("class", "")
+        settings = param.get("settings", {})
+        device_class = settings.get("class", "")
         # Return None for empty/none classes
         if device_class and device_class.lower() not in ("", "none"):
+            if device_class.lower() == "battery":
+                unit = settings.get("unit", "")
+                # "%" is the only unit HA accepts for the battery class, so
+                # anything else means params.json meant "battery-related".
+                if unit and unit.strip() != "%":
+                    return _infer_device_class_from_unit(unit)
             return device_class
 
     return None

--- a/tests/test_param_loader.py
+++ b/tests/test_param_loader.py
@@ -467,3 +467,63 @@ class TestGitHubParamsUpdate:
         params = get_all_params()
         assert isinstance(params, dict)
         assert "SOC" in params  # Known param should still exist
+
+class TestStandardPidFallbacks:
+    """Standard Mode 01 PIDs that params.json has never described."""
+
+    def test_control_module_voltage(self) -> None:
+        """PID 0x42 resolves through every alias spelling."""
+        for name in (
+            "42-ControlModuleVolt",
+            "42_ControlModuleVolt",
+            "ControlModuleVolt",
+            "CTRL_MOD_V",
+        ):
+            assert get_param_unit(name) == "V", name
+            assert get_param_device_class(name) == "voltage", name
+
+    def test_ambient_air_temperature(self) -> None:
+        """PID 0x46 resolves to the unit HA accepts for temperature."""
+        for name in ("46-AmbientAirTemp", "AmbientAirTemp", "AMBIENT_TMP"):
+            assert get_param_unit(name) == "°C", name
+            assert get_param_device_class(name) == "temperature", name
+
+    def test_remaining_gap_pids(self) -> None:
+        """The other four alias targets that pointed at nothing."""
+        assert get_param_unit("33-AbsBaroPres") == "kPa"
+        assert get_param_device_class("33-AbsBaroPres") == "pressure"
+
+        assert get_param_unit("21-DistanceMILOn") == "km"
+        assert get_param_device_class("21-DistanceMILOn") == "distance"
+
+        assert get_param_unit("04-CalcEngineLoad") == "%"
+        assert get_param_device_class("04-CalcEngineLoad") is None
+
+        assert get_param_unit("0E-TimingAdvance") == "deg"
+        assert get_param_device_class("0E-TimingAdvance") is None
+
+    def test_descriptions_available(self) -> None:
+        """Fallbacks carry a description like params.json entries do."""
+        assert get_param_description("42-ControlModuleVolt") == "Control Module Voltage"
+        assert get_param_description("46-AmbientAirTemp") == "Ambient Air Temperature"
+
+    def test_fallbacks_are_not_binary_sensors(self) -> None:
+        """None of the fallbacks declare a binary_sensor type."""
+        for name in ("42-ControlModuleVolt", "46-AmbientAirTemp", "04-CalcEngineLoad"):
+            assert is_binary_sensor(name) is False, name
+
+    def test_icons_resolve(self) -> None:
+        """PIDs without a device class still get a meaningful icon."""
+        assert get_param_icon("04-CalcEngineLoad", None) == "mdi:engine"
+        assert get_param_icon("0E-TimingAdvance", None) == "mdi:timer-cog-outline"
+
+    def test_params_json_still_wins(self) -> None:
+        """A name present in params.json is not shadowed by the fallbacks."""
+        assert get_param_unit("SOC") == "%"
+        assert get_param_unit("05-EngineCoolantTemp") == "°C"
+
+    def test_unknown_name_still_returns_none(self) -> None:
+        """Names in neither source keep returning None."""
+        assert get_param_unit("totally_unknown") is None
+        assert get_param_device_class("totally_unknown") is None
+        assert get_param_description("totally_unknown") is None

--- a/tests/test_param_loader.py
+++ b/tests/test_param_loader.py
@@ -8,6 +8,7 @@ from custom_components.wican.param_loader import (
     get_param_unit,
     get_param_device_class,
     get_param_icon,
+    _infer_device_class_from_unit,
     get_param_description,
     is_binary_sensor,
     get_all_params,
@@ -527,3 +528,53 @@ class TestStandardPidFallbacks:
         assert get_param_unit("totally_unknown") is None
         assert get_param_device_class("totally_unknown") is None
         assert get_param_description("totally_unknown") is None
+
+
+class TestDeviceClassInferredFromUnit:
+    """params.json overloads "battery"; the unit says what the value really is."""
+
+    def test_infer_from_unit_directly(self) -> None:
+        """The unit table covers the electrical units params.json uses."""
+        assert _infer_device_class_from_unit("V") == "voltage"
+        assert _infer_device_class_from_unit("mV") == "voltage"
+        assert _infer_device_class_from_unit("A") == "current"
+        assert _infer_device_class_from_unit("mA") == "current"
+        assert _infer_device_class_from_unit("kW") == "power"
+        assert _infer_device_class_from_unit("kWh") == "energy_storage"
+
+    def test_infer_is_case_insensitive_and_trims(self) -> None:
+        """Units are compared case-insensitively."""
+        assert _infer_device_class_from_unit(" v ") == "voltage"
+        assert _infer_device_class_from_unit("KWH") == "energy_storage"
+
+    def test_units_with_no_ha_device_class(self) -> None:
+        """Ah has no Home Assistant device class, so no class is invented."""
+        assert _infer_device_class_from_unit("Ah") is None
+        assert _infer_device_class_from_unit("") is None
+        assert _infer_device_class_from_unit(None) is None
+
+    def test_battery_with_voltage_unit(self) -> None:
+        """A "battery" param measured in volts is a voltage sensor.
+
+        HA accepts only "%" for the battery device class, so these used to
+        lose their class entirely.
+        """
+        assert get_param_device_class("LV_V") == "voltage"
+        assert get_param_device_class("AC_C_V") == "voltage"
+
+    def test_battery_with_percent_unit_is_untouched(self) -> None:
+        """A real state-of-charge percentage keeps the battery class."""
+        assert get_param_device_class("SOC") == "battery"
+        assert get_param_device_class("SOC_MIN") == "battery"
+
+    def test_battery_with_unmappable_unit(self) -> None:
+        """Ah is battery-related but has no device class; better none than wrong."""
+        assert get_param_device_class("HV_CAPACITY") is None
+        assert get_param_device_class("BATT_CAPACITY") is None
+
+    def test_non_battery_classes_are_untouched(self) -> None:
+        """Only the overloaded "battery" class is reinterpreted."""
+        assert get_param_device_class("HV_V") == "voltage"
+        assert get_param_device_class("COOLANT_TMP") == "temperature"
+        assert get_param_device_class("SPEED") == "speed"
+        assert get_param_device_class("THROTTLE") is None


### PR DESCRIPTION
params.json uses class "battery" loosely, to mean "something about the
battery", and pairs it with whatever unit the value actually has. Home
Assistant accepts only "%" for that device class, so _normalize_device_class()
correctly dropped it - and 198 parameters ended up with no device class, no
unit conversion and the generic mdi:car-info icon. That includes every
HV_C_V_nnn cell voltage, LV_V, AC_C_V, CAPACITOR and HV_C_DIFF. The entity
dump from a real e-Golf shows HV_C_V_001 reporting volts with no device
class while HV_C_V_MIN, which upstream classes "voltage", is correct.

The unit says what the value really is, so infer from it: V/mV/kV ->
voltage, A/mA -> current, W/kW/MW -> power, Wh/kWh/MWh -> energy_storage.
Units with no matching Home Assistant device class, such as Ah, keep no
class rather than being given a wrong one.

Upstream has already made this correction for a few entries by hand
(AC_C_C -> current, HV_AV -> power, KWH_CHARGED -> energy); this applies
the same reading to the rest. Against the full 342-parameter params.json
this recovers 196 cell voltages, leaving only the two Ah capacities
without a class.

Depends on https://github.com/jay-oswald/ha-wican/pull/84