### PR TITLE
Name entities from their descriptions instead of the raw PID key

### DIFF
--- a/custom_components/wican/binary_sensor.py
+++ b/custom_components/wican/binary_sensor.py
@@ -17,7 +17,12 @@ from homeassistant.helpers.restore_state import RestoreEntity
 from .attributes import BINARY_SENSOR_DESCRIPTIONS, WiCANBinarySensorEntityDescription, get_sensor_attributes
 from .const import DOMAIN
 from .entity import WiCANEntity
-from .param_loader import get_param_device_class, get_param_icon, is_binary_sensor
+from .param_loader import (
+    get_param_device_class,
+    get_param_display_name,
+    get_param_icon,
+    is_binary_sensor,
+)
 
 if TYPE_CHECKING:
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -125,7 +130,7 @@ def _build_pid_binary_sensor(
 
     entity_description = WiCANBinarySensorEntityDescription(
         key=pid_key,
-        name=pid_key,
+        name=get_param_display_name(pid_key),
         device_class=device_class,
         icon=icon,
     )

--- a/custom_components/wican/binary_sensor.py
+++ b/custom_components/wican/binary_sensor.py
@@ -3,16 +3,21 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
     BinarySensorEntity,
 )
+from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from .attributes import BINARY_SENSOR_DESCRIPTIONS, WiCANBinarySensorEntityDescription, get_sensor_attributes
+from .const import DOMAIN
 from .entity import WiCANEntity
+from .param_loader import get_param_device_class, get_param_icon, is_binary_sensor
 
 if TYPE_CHECKING:
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -24,13 +29,111 @@ PARALLEL_UPDATES = 0
 
 TRUE_STRINGS = {"enable", "true", "online"}
 
+# A PID marked as a binary sensor in params.json reports "on"/"off" strings,
+# but firmware versions and vehicle profiles vary, so accept the usual
+# spellings and plain numbers too. Anything else leaves the state untouched
+# rather than guessing - bool() on a non-empty string would read "off" as on.
+_PID_TRUE_VALUES = {"1", "active", "enable", "enabled", "on", "online", "true", "yes"}
+_PID_FALSE_VALUES = {"0", "disable", "disabled", "false", "inactive", "no", "off", "offline"}
+
+# Entities created dynamically from webhook data, keyed by config entry id.
+DYNAMIC_PID_BINARY_SENSORS = {}
+
+
 def is_true_status(value: str) -> bool:
     if isinstance(value, str):
         return value.strip().lower() in TRUE_STRINGS
     return bool(value)
 
-async def async_setup_entry(
-    _hass: HomeAssistant,
+
+def pid_value_to_is_on(value: Any) -> bool | None:  # noqa: PLR0911
+    """Interpret a PID value as a binary state.
+
+    Args:
+        value: Raw value for the PID from the webhook payload.
+
+    Returns:
+        True or False, or None when the value cannot be interpreted, in which
+        case the caller should keep the previous state.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+
+    text = str(value).strip().lower()
+    if text in _PID_TRUE_VALUES:
+        return True
+    if text in _PID_FALSE_VALUES:
+        return False
+
+    try:
+        return float(text) != 0
+    except ValueError:
+        _LOGGER.debug("Cannot interpret %r as a binary sensor state", value)
+        return None
+
+
+def _get_pid_device_class(
+    pid_key: str,
+    config_class: str | None = None,
+) -> BinarySensorDeviceClass | None:
+    """Resolve a binary sensor device class for a PID.
+
+    Args:
+        pid_key: The PID sensor key/name from the device.
+        config_class: Device class from the device config, if any.
+
+    Returns:
+        Valid BinarySensorDeviceClass or None.
+    """
+    device_class = config_class
+    if isinstance(device_class, str) and device_class.lower() in ("", "none"):
+        device_class = None
+
+    if device_class is None:
+        device_class = get_param_device_class(pid_key)
+
+    if not device_class:
+        return None
+
+    try:
+        return BinarySensorDeviceClass(str(device_class).lower())
+    except ValueError:
+        _LOGGER.debug(
+            "Invalid binary sensor device class '%s' for %s, ignoring",
+            device_class, pid_key,
+        )
+        return None
+
+
+def _build_pid_binary_sensor(
+    config_entry: WiCANConfigEntry,
+    pid_key: str,
+    config: dict[str, Any],
+) -> WiCANPidBinarySensorEntity:
+    """Build a dynamic PID binary sensor entity."""
+    device_class = _get_pid_device_class(pid_key, config.get("class"))
+    icon = get_param_icon(pid_key, device_class.value if device_class else None)
+
+    _LOGGER.debug(
+        "Creating PID binary sensor %s with device_class=%s, icon=%s",
+        pid_key, device_class, icon,
+    )
+
+    entity_description = WiCANBinarySensorEntityDescription(
+        key=pid_key,
+        name=pid_key,
+        device_class=device_class,
+        icon=icon,
+    )
+    return WiCANPidBinarySensorEntity(config_entry, pid_key, entity_description)
+
+
+async def async_setup_entry(  # noqa: C901
+    hass: HomeAssistant,
     config_entry: WiCANConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
@@ -40,6 +143,73 @@ async def async_setup_entry(
         WiCANBinarySensorEntity(config_entry, description)
         for description in BINARY_SENSOR_DESCRIPTIONS
     )
+
+    DYNAMIC_PID_BINARY_SENSORS[config_entry.entry_id] = {}
+
+    @callback
+    def _async_forget_entry() -> None:
+        """Drop this entry's entity map so removed entries leave nothing behind."""
+        DYNAMIC_PID_BINARY_SENSORS.pop(config_entry.entry_id, None)
+
+    config_entry.async_on_unload(_async_forget_entry)
+
+    # Restore PID binary sensors from the config entry
+    stored_config = config_entry.data.get("config", {})
+    restored_entities = []
+    for pid_key in config_entry.data.get("pid_keys", []):
+        if not is_binary_sensor(pid_key):
+            # Owned by the sensor platform.
+            continue
+        entity = _build_pid_binary_sensor(
+            config_entry, pid_key, stored_config.get(pid_key, {}),
+        )
+        DYNAMIC_PID_BINARY_SENSORS[config_entry.entry_id][pid_key] = entity
+        restored_entities.append(entity)
+
+    if restored_entities:
+        async_add_entities(restored_entities)
+
+    async def _async_process_pid_update(data):
+        pid_data = data.get("autopid_data", {})
+        if not pid_data:
+            return
+
+        # A webhook can already be queued when the entry unloads, so the map
+        # may be gone by the time this task runs.
+        sensors = DYNAMIC_PID_BINARY_SENSORS.get(config_entry.entry_id)
+        if sensors is None:
+            return
+
+        webhook_config = data.get("config", {})
+        new_entities = []
+        for pid_key in pid_data:
+            if pid_key in sensors or not is_binary_sensor(pid_key):
+                continue
+            entity = _build_pid_binary_sensor(
+                config_entry, pid_key, webhook_config.get(pid_key, {}),
+            )
+            sensors[pid_key] = entity
+            new_entities.append(entity)
+
+        # pid_keys and config are persisted by the sensor platform, which sees
+        # the same payload and stores every PID regardless of which platform
+        # owns it.
+        if new_entities:
+            async_add_entities(new_entities)
+
+    def handle_pid_update(webhook_id, data):
+        # IMPORTANT: multiple WiCAN entries share the same dispatcher signal.
+        # Filter by this entry's webhook_id to avoid cross-device entity creation.
+        if webhook_id != config_entry.runtime_data.webhook_id:
+            return
+        hass.loop.call_soon_threadsafe(
+            hass.async_create_task,
+            _async_process_pid_update(data),
+        )
+
+    unsub = async_dispatcher_connect(hass, DOMAIN, handle_pid_update)
+    config_entry.async_on_unload(unsub)
+
 
 class WiCANBinarySensorEntity(WiCANEntity, BinarySensorEntity, RestoreEntity):
     """A binary sensor entity."""
@@ -80,4 +250,50 @@ class WiCANBinarySensorEntity(WiCANEntity, BinarySensorEntity, RestoreEntity):
         last_state = await self.async_get_last_state()
         if last_state is not None and self._attr_is_on is None:
             self._attr_is_on = last_state.state == "on"
+        await super().async_added_to_hass()
+
+
+class WiCANPidBinarySensorEntity(WiCANEntity, BinarySensorEntity, RestoreEntity):
+    """Dynamic PID binary sensor entity.
+
+    Vehicle profiles mark parameters such as CHARGING, CHARGER_CONNECTED and
+    PARK_BRAKE as binary in params.json. They used to be created as regular
+    sensors holding the strings "on" and "off", which cannot drive a state
+    condition, a device trigger, or a plug/charging device class.
+    """
+
+    __slots__ = ("_attr_is_on", "_pid_key")
+
+    entity_description: WiCANBinarySensorEntityDescription
+
+    def __init__(self, config_entry, pid_key, entity_description):
+        super().__init__(config_entry, entity_description)
+        self._pid_key = pid_key
+        self._attr_unique_id = f"{config_entry.entry_id}_pid_{pid_key}"
+        self._attr_is_on = None
+
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        pid_data = self.coordinator.data.get("autopid_data", {})
+
+        if self._pid_key in pid_data:
+            is_on = pid_value_to_is_on(pid_data[self._pid_key])
+            if is_on is not None:
+                self._attr_is_on = is_on
+                self.async_write_ha_state()
+
+    @callback
+    def _async_handle_event(self, webhook_id: str, data) -> None:
+        """Handle webhook event (backward compatibility)."""
+        # Coordinator update will trigger _handle_coordinator_update()
+
+    async def async_added_to_hass(self) -> None:
+        """Restore entity state."""
+        last_state = await self.async_get_last_state()
+        if (
+            last_state is not None
+            and self._attr_is_on is None
+            and last_state.state in (STATE_ON, STATE_OFF)
+        ):
+            self._attr_is_on = last_state.state == STATE_ON
         await super().async_added_to_hass()

--- a/custom_components/wican/entity.py
+++ b/custom_components/wican/entity.py
@@ -35,7 +35,12 @@ class WiCANEntity(CoordinatorEntity[WiCANDataUpdateCoordinator]):
         self._attr_unique_id = f"{config_entry.entry_id}_{entity_description.key}"
         self.entity_description = entity_description
         self.webhook_id = config_entry.runtime_data.webhook_id
-        self._attr_name = entity_description.key
+        # Deliberately no _attr_name: it takes priority over translation_key
+        # in Entity._name_internal(), so setting it here made every name in
+        # translations/en.json dead and left the static sensors called
+        # "batt_voltage" rather than "Battery Voltage". Platforms that have no
+        # translation set entity_description.name instead, which is consulted
+        # after the translation.
         self._attr_device_info = DeviceInfo(
             connections={(DOMAIN, config_entry.entry_id)},
             manufacturer="MeatPi",
@@ -70,6 +75,20 @@ class WiCANEntity(CoordinatorEntity[WiCANDataUpdateCoordinator]):
         """Handle updated data from the coordinator."""
         # Default implementation - subclasses should override this
         self.async_write_ha_state()
+
+    @property
+    def suggested_object_id(self) -> str | None:
+        """Derive the entity id from the raw key, not the display name.
+
+        Home Assistant builds an entity id from the entity's name by default,
+        so improving the names would have renamed every entity id on new
+        installs while leaving existing ones on the old scheme - two installs
+        of the same version disagreeing about what to call the same sensor.
+        Keying it off the raw key keeps ids stable and predictable
+        (sensor.<device>_batt_voltage, sensor.<device>_soc) whatever the
+        display name says.
+        """
+        return self.entity_description.key
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/wican/param_loader.py
+++ b/custom_components/wican/param_loader.py
@@ -641,6 +641,22 @@ def get_param_device_class(param_name: str) -> str | None:
     return None
 
 
+def get_param_display_name(param_name: str) -> str:
+    """Get a human-readable name for a parameter.
+
+    params.json already carries a description for every parameter it knows
+    ("Cell Voltage 001", "Control Module Voltage", "State Of Charge"), which
+    reads far better than the raw key the device sends.
+
+    Args:
+        param_name: Parameter name (case-insensitive, supports various formats).
+
+    Returns:
+        The parameter's description, or the key unchanged when there is none.
+    """
+    return get_param_description(param_name) or param_name
+
+
 def get_param_icon(param_name: str, device_class: str | None = None) -> str:
     """Get the icon for a parameter.
 

--- a/custom_components/wican/sensor.py
+++ b/custom_components/wican/sensor.py
@@ -19,6 +19,7 @@ from .param_loader import (
     get_param_device_class,
     get_param_icon,
     get_param_unit,
+    is_binary_sensor,
     is_valid_class_unit_combo,
     is_valid_device_class,
 )
@@ -140,7 +141,7 @@ def _normalize_device_class(
 DYNAMIC_PID_SENSORS = {}
 
 
-async def async_setup_entry(  # noqa: C901
+async def async_setup_entry(  # noqa: C901, PLR0915
     hass: HomeAssistant,
     config_entry: WiCANConfigEntry,
     async_add_entities: AddEntitiesCallback,
@@ -159,6 +160,9 @@ async def async_setup_entry(  # noqa: C901
     pid_config = config_entry.data.get("config", {})
     restored_entities = []
     for pid_key in pid_keys:
+        if is_binary_sensor(pid_key):
+            # Owned by the binary_sensor platform.
+            continue
         config = pid_config.get(pid_key, {})
         # Use _get_pid_unit with config unit for consistent fallback handling
         unit = _get_pid_unit(pid_key, config.get("unit"))
@@ -194,6 +198,9 @@ async def async_setup_entry(  # noqa: C901
         sensors = DYNAMIC_PID_SENSORS[config_entry.entry_id]
 
         for pid_key in pid_data:
+            if is_binary_sensor(pid_key):
+                # Owned by the binary_sensor platform.
+                continue
             if pid_key not in sensors:
                 config = pid_config.get(pid_key, {})
                 # Use _get_pid_unit with config unit for consistent fallback handling
@@ -217,16 +224,25 @@ async def async_setup_entry(  # noqa: C901
                 new_entities.append(entity)
                 sensors[pid_key] = entity
 
-        if new_entities:
-            pid_keys = set(sensors.keys())
-            existing_config = dict(config_entry.data.get("config", {}))
-            for pid_key in pid_data:
-                if pid_key in pid_config:
-                    existing_config[pid_key] = pid_config[pid_key]
+        # Persist every PID seen, including the ones the binary_sensor platform
+        # owns, so both platforms can restore their entities on restart.
+        known_keys = set(config_entry.data.get("pid_keys", []))
+        all_keys = known_keys | set(pid_data)
+        existing_config = dict(config_entry.data.get("config", {}))
+        updated_config = dict(existing_config)
+        for pid_key in pid_data:
+            if pid_key in pid_config:
+                updated_config[pid_key] = pid_config[pid_key]
+
+        # Only write when something actually changed - updating the entry
+        # fires the update listener, which re-registers the webhook.
+        if all_keys != known_keys or updated_config != existing_config:
             new_data = dict(config_entry.data)
-            new_data["pid_keys"] = list(pid_keys)
-            new_data["config"] = existing_config
+            new_data["pid_keys"] = list(all_keys)
+            new_data["config"] = updated_config
             hass.config_entries.async_update_entry(config_entry, data=new_data)
+
+        if new_entities:
             async_add_entities(new_entities)
 
     def handle_pid_update(webhook_id, data):

--- a/custom_components/wican/sensor.py
+++ b/custom_components/wican/sensor.py
@@ -17,6 +17,7 @@ from .const import DOMAIN
 from .entity import WiCANEntity
 from .param_loader import (
     get_param_device_class,
+    get_param_display_name,
     get_param_icon,
     get_param_unit,
     is_binary_sensor,
@@ -176,7 +177,7 @@ async def async_setup_entry(  # noqa: C901, PLR0915
 
         entity_description = WiCANSensorEntityDescription(
             key=pid_key,
-            name=pid_key,
+            name=get_param_display_name(pid_key),
             device_class=device_class,
             native_unit_of_measurement=unit,
             state_class="measurement",
@@ -215,7 +216,7 @@ async def async_setup_entry(  # noqa: C901, PLR0915
 
                 entity_description = WiCANSensorEntityDescription(
                     key=pid_key,
-                    name=pid_key,
+                    name=get_param_display_name(pid_key),
                     device_class=device_class,
                     native_unit_of_measurement=unit,
                     icon=icon,

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -10,6 +10,10 @@ from homeassistant.const import CONF_WEBHOOK_ID, STATE_ON, STATE_OFF
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
+from custom_components.wican.binary_sensor import (
+    DYNAMIC_PID_BINARY_SENSORS,
+    pid_value_to_is_on,
+)
 from custom_components.wican.const import DOMAIN
 
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -249,3 +253,140 @@ async def test_binary_sensor_none_checks(hass: HomeAssistant, hass_client) -> No
     # Verify entities exist and didn't crash
     state = hass.states.get("binary_sensor.wican_test_ble_status")
     assert state is not None
+
+
+async def test_profile_binary_pids_become_binary_sensors(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_webhook_data: dict,
+    hass_client,
+) -> None:
+    """PIDs marked binary in params.json get a binary_sensor, not a sensor.
+
+    CHARGING and CHARGER_CONNECTED report the strings "on" and "off", which
+    as sensor states cannot drive a state condition or a device trigger.
+    """
+    entry = init_integration
+    webhook_id = entry.data[CONF_WEBHOOK_ID]
+
+    data = dict(mock_webhook_data)
+    data["autopid_data"] = {
+        "CHARGING": "on",
+        "CHARGER_CONNECTED": "off",
+        "SOC": 62,
+    }
+    data["config"] = {
+        "CHARGING": {"unit": "", "class": "battery_charging"},
+        "CHARGER_CONNECTED": {"unit": "", "class": "plug"},
+        "SOC": {"unit": "%", "class": "battery"},
+    }
+
+    client = await hass_client()
+    await client.post(f"/api/webhook/{webhook_id}", json=data)
+    await hass.async_block_till_done()
+
+    charging = hass.states.get("binary_sensor.wican_device_charging")
+    assert charging is not None
+    assert charging.state == STATE_ON
+    assert charging.attributes.get("device_class") == "battery_charging"
+
+    plugged = hass.states.get("binary_sensor.wican_device_charger_connected")
+    assert plugged is not None
+    assert plugged.state == STATE_OFF
+    assert plugged.attributes.get("device_class") == "plug"
+
+    # The same PIDs must not also appear on the sensor platform
+    assert hass.states.get("sensor.wican_device_charging") is None
+    assert hass.states.get("sensor.wican_device_charger_connected") is None
+
+    # Non-binary PIDs are untouched
+    assert hass.states.get("sensor.wican_device_soc") is not None
+
+
+async def test_binary_pids_restored_from_config_entry(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Binary PIDs stored on the entry are recreated on the right platform."""
+    entry_data = dict(mock_config_entry.data)
+    entry_data["pid_keys"] = ["CHARGING", "PARK_BRAKE", "SOC"]
+    entry_data["config"] = {
+        "CHARGING": {"unit": "", "class": "battery_charging"},
+        "PARK_BRAKE": {"unit": "none", "class": "none"},
+        "SOC": {"unit": "%", "class": "battery"},
+    }
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="WiCAN Device",
+        data=entry_data,
+        options=mock_config_entry.options,
+        unique_id=mock_config_entry.unique_id,
+    )
+    entry.add_to_hass(hass)
+
+    with patch("custom_components.wican.async_get_clientsession"), patch(
+        "custom_components.wican.WiCANDataUpdateCoordinator.async_config_entry_first_refresh",
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    entity_registry = er.async_get(hass)
+    assert entity_registry.async_get("binary_sensor.wican_device_charging") is not None
+    assert entity_registry.async_get("binary_sensor.wican_device_park_brake") is not None
+    assert entity_registry.async_get("sensor.wican_device_soc") is not None
+    assert entity_registry.async_get("sensor.wican_device_charging") is None
+
+
+async def test_binary_pid_map_cleared_on_unload(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_webhook_data: dict,
+    hass_client,
+) -> None:
+    """The dynamic binary sensor map does not outlive the config entry."""
+    entry = init_integration
+
+    data = dict(mock_webhook_data)
+    data["autopid_data"] = {"CHARGING": "on"}
+    data["config"] = {"CHARGING": {"unit": "", "class": "battery_charging"}}
+
+    client = await hass_client()
+    await client.post(f"/api/webhook/{entry.data[CONF_WEBHOOK_ID]}", json=data)
+    await hass.async_block_till_done()
+
+    assert "CHARGING" in DYNAMIC_PID_BINARY_SENSORS[entry.entry_id]
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.entry_id not in DYNAMIC_PID_BINARY_SENSORS
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("on", True),
+        ("ON", True),
+        (" on ", True),
+        ("off", False),
+        ("OFF", False),
+        ("true", True),
+        ("false", False),
+        ("enable", True),
+        ("disable", False),
+        (1, True),
+        (0, False),
+        ("1", True),
+        ("0", False),
+        (1.0, True),
+        (0.0, False),
+        (True, True),
+        (False, False),
+        (None, None),
+        ("wat", None),
+        ("", None),
+    ],
+)
+def test_pid_value_to_is_on(value, expected) -> None:
+    """"off" must read as off - bool("off") is True."""
+    assert pid_value_to_is_on(value) is expected

--- a/tests/test_param_loader.py
+++ b/tests/test_param_loader.py
@@ -9,6 +9,7 @@ from custom_components.wican.param_loader import (
     get_param_device_class,
     get_param_icon,
     get_param_description,
+    get_param_display_name,
     is_binary_sensor,
     get_all_params,
      is_valid_device_class,
@@ -467,3 +468,21 @@ class TestGitHubParamsUpdate:
         params = get_all_params()
         assert isinstance(params, dict)
         assert "SOC" in params  # Known param should still exist
+
+
+class TestGetParamDisplayName:
+    """Tests for get_param_display_name function."""
+
+    def test_uses_the_description(self) -> None:
+        """params.json already carries a readable name for every param."""
+        assert get_param_display_name("SOC") == "State Of Charge"
+        assert get_param_display_name("HV_V") == "High Voltage Battery Voltage"
+
+    def test_falls_back_to_the_key(self) -> None:
+        """A PID with no description - unknown, or a hex-prefixed standard
+        PID alias that params.json has never heard of - keeps the raw key
+        the device gave it. Resolving those aliases to a real name needs the
+        fallback table from fix-standard-pid-fallbacks, not present here.
+        """
+        assert get_param_display_name("SOME_CUSTOM_PID") == "SOME_CUSTOM_PID"
+        assert get_param_display_name("42-ControlModuleVolt") == "42-ControlModuleVolt"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -299,3 +299,92 @@ async def test_sensor_state_restoration_with_normalization(hass: HomeAssistant) 
 
 
 
+
+
+async def test_entity_names_come_from_translations_and_descriptions(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Static sensors use their translation, PID sensors use params.json.
+
+    WiCANEntity used to set _attr_name to the raw key, which takes priority
+    over translation_key in Entity._name_internal() - so every name in
+    translations/en.json was dead and PID sensors were called HV_V.
+    """
+    entry_data = dict(mock_config_entry.data)
+    entry_data["pid_keys"] = ["SOC", "HV_V", "UNKNOWN_PID"]
+    entry_data["config"] = {
+        "SOC": {"unit": "%", "class": "battery"},
+        "HV_V": {"unit": "V", "class": "battery"},
+        "UNKNOWN_PID": {"unit": "", "class": "none"},
+    }
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="WiCAN Device",
+        data=entry_data,
+        options=mock_config_entry.options,
+        unique_id=mock_config_entry.unique_id,
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.wican._async_register_webhook_on_device",
+        return_value=True,
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    def friendly(entity_id: str) -> str | None:
+        state = hass.states.get(entity_id)
+        assert state is not None, entity_id
+        return state.attributes.get("friendly_name")
+
+    # Static sensor, named by translations/en.json
+    assert friendly("sensor.wican_device_batt_voltage") == "WiCAN Device Battery Voltage"
+    # PID sensors, named by their params.json description
+    assert friendly("sensor.wican_device_soc") == "WiCAN Device State Of Charge"
+    assert friendly("sensor.wican_device_hv_v") == "WiCAN Device High Voltage Battery Voltage"
+    # A PID params.json has never heard of keeps its raw key
+    assert friendly("sensor.wican_device_unknown_pid") == "WiCAN Device UNKNOWN_PID"
+
+
+async def test_entity_ids_stay_keyed_on_the_raw_pid(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Renaming the entities must not renumber their entity ids.
+
+    HA derives an entity id from the name, so without suggested_object_id a
+    fresh install would get sensor.<device>_state_of_charge while an existing
+    one kept sensor.<device>_soc.
+    """
+    entry_data = dict(mock_config_entry.data)
+    entry_data["pid_keys"] = ["SOC", "HV_V"]
+    entry_data["config"] = {
+        "SOC": {"unit": "%", "class": "battery"},
+        "HV_V": {"unit": "V", "class": "battery"},
+    }
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="WiCAN Device",
+        data=entry_data,
+        options=mock_config_entry.options,
+        unique_id=mock_config_entry.unique_id,
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.wican._async_register_webhook_on_device",
+        return_value=True,
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    entity_registry = er.async_get(hass)
+    for entity_id in (
+        "sensor.wican_device_batt_voltage",
+        "sensor.wican_device_wifi_mode",
+        "sensor.wican_device_soc",
+        "sensor.wican_device_hv_v",
+    ):
+        assert entity_registry.async_get(entity_id) is not None, entity_id


### PR DESCRIPTION
WiCANEntity set _attr_name to the entity description's key. That takes
priority over translation_key in Entity._name_internal(), so every name
in translations/en.json was dead code and the entities read
"wican_xxx.local. batt_voltage" and "wican_xxx.local. HV_C_V_001".

Drop it, and the two existing mechanisms take over:

  - static entities fall through to their translation_key, giving
    "Battery Voltage", "WiFi Mode", "Bluetooth Enabled";
  - dynamic PID entities set entity_description.name, which is consulted
    after the translation, from params.json's own description via
    get_param_display_name(): "State Of Charge", "Cell Voltage 001",
    "Control Module Voltage". A PID params.json has never heard of keeps
    the raw key it came with.

Entity ids are deliberately unaffected. HA derives them from the name,
so this would otherwise have renumbered everything on new installs while
leaving existing installs on the old scheme - two installs of the same
version disagreeing about what to call the same sensor. Overriding
suggested_object_id keys them off the raw PID instead, so
sensor.<device>_soc and sensor.<device>_batt_voltage stay put whatever
the display name says.

Depends on https://github.com/jay-oswald/ha-wican/pull/76