### PR TITLE
Report uptime as a duration, not free text

### DIFF
--- a/custom_components/wican/attributes.py
+++ b/custom_components/wican/attributes.py
@@ -1,7 +1,12 @@
 from dataclasses import dataclass, field
 
 from homeassistant.components.binary_sensor import BinarySensorEntityDescription
-from homeassistant.components.sensor import SensorDeviceClass, SensorEntityDescription
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntityDescription,
+    SensorStateClass,
+)
+from homeassistant.const import UnitOfTime
 from homeassistant.helpers.entity import EntityCategory
 
 
@@ -56,6 +61,10 @@ SENSOR_DESCRIPTIONS: tuple[WiCANSensorEntityDescription, ...] = (
         translation_key="uptime",
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:clock-outline",
+        device_class=SensorDeviceClass.DURATION,
+        native_unit_of_measurement=UnitOfTime.SECONDS,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
     ),
 )
 

--- a/custom_components/wican/coordinator.py
+++ b/custom_components/wican/coordinator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 import logging
+import re
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.exceptions import ConfigEntryError
@@ -21,6 +22,30 @@ _LOGGER = logging.getLogger(__name__)
 # WiCAN is push-based via webhooks, so we don't need frequent polling
 # This is just for fallback/health check
 UPDATE_INTERVAL = timedelta(seconds=WICAN_DATA_UPDATE_INTERVAL)
+
+# Matches the firmware's dev_status_format_uptime() output: "HH:MM:SS" or,
+# once uptime passes 24h, "Nd HH:MM:SS".
+_UPTIME_RE = re.compile(r"^(?:(\d+)d\s+)?(\d+):(\d{2}):(\d{2})$")
+
+
+def _parse_uptime_seconds(value: str) -> int | None:
+    """Convert the firmware's formatted uptime string to whole seconds.
+
+    The device reports "N/A" when it has no reading yet, and otherwise
+    "HH:MM:SS" or "Dd HH:MM:SS" - never a raw number - so the sensor needs a
+    numeric value before it can carry a duration device/state class.
+
+    Args:
+        value: The raw "uptime" string from the webhook or status payload.
+
+    Returns:
+        Total whole seconds, or None if the value isn't a recognized uptime.
+    """
+    match = _UPTIME_RE.match(value.strip())
+    if not match:
+        return None
+    days, hours, minutes, seconds = (int(part or 0) for part in match.groups())
+    return ((days * 24 + hours) * 60 + minutes) * 60 + seconds
 
 
 class WiCANDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
@@ -146,6 +171,12 @@ class WiCANDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """
         if raw_value is None:
             return None
+
+        # Uptime: the device reports "HH:MM:SS" / "Nd HH:MM:SS" / "N/A", never
+        # a number. A duration sensor needs seconds, so convert here rather
+        # than leaving a formatted string HA can only display as text.
+        if key == "uptime" and isinstance(raw_value, str):
+            return _parse_uptime_seconds(raw_value)
 
         # Battery voltage: strip "V" / " V" suffix (any case) and convert to float
         # Handles firmware variants: "12.5V", "12.5 V", "12.5v", " 12.5 V "

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -72,7 +72,35 @@ async def test_sensor_states_update_from_webhook(
 
     uptime_state = hass.states.get("sensor.wican_device_uptime")
     assert uptime_state is not None
-    assert uptime_state.state == "01:00:00"
+    # "01:00:00" from the device normalizes to whole seconds so the sensor
+    # can carry a duration device/state class.
+    assert uptime_state.state == "3600"
+    assert uptime_state.attributes.get("device_class") == "duration"
+    assert uptime_state.attributes.get("state_class") == "measurement"
+    assert uptime_state.attributes.get("unit_of_measurement") == "s"
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("01:00:00", 3600),
+        ("00:00:00", 0),
+        ("3d 04:05:06", 273906),
+        ("N/A", None),
+        ("garbage", None),
+    ],
+)
+async def test_uptime_normalization(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    raw: str,
+    expected: int | None,
+) -> None:
+    """Uptime strings from the firmware convert to whole seconds."""
+    entry = init_integration
+    coordinator = entry.runtime_data.coordinator
+
+    assert coordinator.normalize_sensor_value("uptime", raw) == expected
 
 
 async def test_pid_sensor_entities_created(


### PR DESCRIPTION
The firmware sends uptime as a preformatted "HH:MM:SS" (or "Nd HH:MM:SS") string, which Home Assistant can only render as a text sensor - it shows up as an enum-like state list in history instead of a graphable value.

Parse the string into whole seconds in the coordinator and give the sensor description a duration device class, so it gets a numeric state, a unit, and a real history graph.