### PR TITLE
Add a Last Update timestamp sensor

### DIFF
--- a/custom_components/wican/attributes.py
+++ b/custom_components/wican/attributes.py
@@ -57,6 +57,13 @@ SENSOR_DESCRIPTIONS: tuple[WiCANSensorEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:clock-outline",
     ),
+    WiCANSensorEntityDescription(
+        key="last_update",
+        translation_key="last_update",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        icon="mdi:update",
+        device_class=SensorDeviceClass.TIMESTAMP,
+    ),
 )
 
 BINARY_SENSOR_DESCRIPTIONS: tuple[WiCANBinarySensorEntityDescription, ...] = (

--- a/custom_components/wican/coordinator.py
+++ b/custom_components/wican/coordinator.py
@@ -8,10 +8,13 @@ from typing import TYPE_CHECKING, Any
 
 from homeassistant.exceptions import ConfigEntryError
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN, WICAN_DATA_UPDATE_INTERVAL
 
 if TYPE_CHECKING:
+    from datetime import datetime
+
     from homeassistant.core import HomeAssistant
 
     from . import WiCANConfigEntry
@@ -34,6 +37,12 @@ class WiCANDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Initialize the coordinator."""
         self.config_entry = config_entry
         self._data: dict[str, Any] = {}
+        # When the device last actually pushed data, as opposed to
+        # last_update_success which this push-based coordinator sets True
+        # once and never re-evaluates. Entities use this to tell a fresh
+        # reading from one the device hasn't refreshed since - e.g. one
+        # that only reports while parked at home on Wi-Fi.
+        self.last_webhook_time: datetime | None = None
 
         super().__init__(
             hass,
@@ -78,6 +87,7 @@ class WiCANDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         # Update internal data store
         self._data.update(data)
+        self.last_webhook_time = dt_util.utcnow()
 
         # Notify all entities that data has been updated
         self.async_set_updated_data(self._data)

--- a/custom_components/wican/sensor.py
+++ b/custom_components/wican/sensor.py
@@ -259,6 +259,15 @@ class WiCANSensorEntity(WiCANEntity, RestoreSensor):
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         key = self.entity_description.key
+
+        if key == "last_update":
+            # Not part of any webhook payload - it's the coordinator's own
+            # record of when it last received one.
+            if self.coordinator.last_webhook_time is not None:
+                self._attr_native_value = self.coordinator.last_webhook_time
+                self.async_write_ha_state()
+            return
+
         status = self.coordinator.data.get("status", {})
 
         if key not in status:

--- a/custom_components/wican/translations/en.json
+++ b/custom_components/wican/translations/en.json
@@ -41,6 +41,9 @@
         },
         "uptime": {
           "name": "Uptime"
+        },
+        "last_update": {
+          "name": "Last Update"
         }
       },
       "binary_sensor": {

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -116,6 +116,25 @@ async def test_coordinator_device_identity_validation_no_device_id(
     assert coordinator.data == no_device_id_data
 
 
+async def test_coordinator_tracks_last_webhook_time(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_webhook_data: dict,
+) -> None:
+    """Test the coordinator records when a webhook was last handled."""
+    coordinator = WiCANDataUpdateCoordinator(hass, mock_config_entry)
+    await coordinator.async_config_entry_first_refresh()
+
+    assert coordinator.last_webhook_time is None
+
+    before = dt_util.utcnow()
+    coordinator.handle_webhook_data(mock_webhook_data)
+    after = dt_util.utcnow()
+
+    assert coordinator.last_webhook_time is not None
+    assert before <= coordinator.last_webhook_time <= after
+
+
 async def test_coordinator_normalize_sensor_value_voltage(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -39,6 +39,10 @@ async def test_sensor_entities_created(
     assert uptime is not None
     assert uptime.unique_id.endswith("_uptime")
 
+    last_update = entity_registry.async_get("sensor.wican_device_last_update")
+    assert last_update is not None
+    assert last_update.unique_id.endswith("_last_update")
+
 
 async def test_sensor_states_update_from_webhook(
     hass: HomeAssistant,
@@ -73,6 +77,55 @@ async def test_sensor_states_update_from_webhook(
     uptime_state = hass.states.get("sensor.wican_device_uptime")
     assert uptime_state is not None
     assert uptime_state.state == "01:00:00"
+
+    last_update_state = hass.states.get("sensor.wican_device_last_update")
+    assert last_update_state is not None
+    assert last_update_state.state != "unknown"
+    assert last_update_state.attributes.get("device_class") == "timestamp"
+
+
+async def test_last_update_sensor_unknown_before_first_webhook(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+) -> None:
+    """The last-update sensor has no value until a webhook ever arrives."""
+    state = hass.states.get("sensor.wican_device_last_update")
+    assert state is not None
+    assert state.state == "unknown"
+
+
+async def test_last_update_sensor_restoration(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_webhook_data: dict,
+    hass_client,
+) -> None:
+    """The last-update timestamp survives a restart."""
+    entry = init_integration
+    client = await hass_client()
+
+    await client.post(
+        f"/api/webhook/{entry.data[CONF_WEBHOOK_ID]}", json=mock_webhook_data,
+    )
+    await hass.async_block_till_done()
+
+    first_state = hass.states.get("sensor.wican_device_last_update")
+    assert first_state is not None
+    assert first_state.state != "unknown"
+
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    with patch(
+        "custom_components.wican._async_register_webhook_on_device",
+        return_value=True,
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    restored_state = hass.states.get("sensor.wican_device_last_update")
+    assert restored_state is not None
+    assert restored_state.state == first_state.state
 
 
 async def test_pid_sensor_entities_created(


### PR DESCRIPTION
WiCAN pushes data over a webhook rather than being polled, and existing entities never go unavailable when the device stops reporting (e.g. the car has driven off Wi-Fi range) - their state is just whatever was last pushed, with no indication of how stale it is.

Track when the coordinator last actually received a webhook push, and expose it as a diagnostic timestamp sensor, so automations and the dashboard can tell a fresh reading from a stale one.