### PR TITLE
Add a Reporting binary sensor for push staleness

### DIFF
--- a/custom_components/wican/attributes.py
+++ b/custom_components/wican/attributes.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass, field
 
-from homeassistant.components.binary_sensor import BinarySensorEntityDescription
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntityDescription,
+)
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntityDescription
 from homeassistant.helpers.entity import EntityCategory
 
@@ -78,6 +81,16 @@ BINARY_SENSOR_DESCRIPTIONS: tuple[WiCANBinarySensorEntityDescription, ...] = (
             "obd_chip_status",
         ],
     ),
+)
+
+# Not part of BINARY_SENSOR_DESCRIPTIONS: it isn't a status key from the
+# device payload, so the generic WiCANBinarySensorEntity has nothing to read
+# for it. See WiCANReportingBinarySensorEntity in binary_sensor.py.
+REPORTING_BINARY_SENSOR_DESCRIPTION = WiCANBinarySensorEntityDescription(
+    key="reporting",
+    translation_key="reporting",
+    device_class=BinarySensorDeviceClass.CONNECTIVITY,
+    entity_category=EntityCategory.DIAGNOSTIC,
 )
 
 def get_sensor_attributes(entity_description, data: dict) -> dict:

--- a/custom_components/wican/binary_sensor.py
+++ b/custom_components/wican/binary_sensor.py
@@ -9,12 +9,21 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.util import dt as dt_util
 
-from .attributes import BINARY_SENSOR_DESCRIPTIONS, WiCANBinarySensorEntityDescription, get_sensor_attributes
+from .attributes import (
+    BINARY_SENSOR_DESCRIPTIONS,
+    REPORTING_BINARY_SENSOR_DESCRIPTION,
+    WiCANBinarySensorEntityDescription,
+    get_sensor_attributes,
+)
+from .const import REPORTING_MIN_TIMEOUT, REPORTING_STALE_MULTIPLIER
 from .entity import WiCANEntity
 
 if TYPE_CHECKING:
+    from homeassistant.core import CALLBACK_TYPE
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
     from . import WiCANConfigEntry
@@ -39,6 +48,18 @@ async def async_setup_entry(
     async_add_entities(
         WiCANBinarySensorEntity(config_entry, description)
         for description in BINARY_SENSOR_DESCRIPTIONS
+    )
+
+    stale_timeout = max(
+        config_entry.runtime_data.post_interval * REPORTING_STALE_MULTIPLIER,
+        REPORTING_MIN_TIMEOUT,
+    )
+    async_add_entities(
+        [
+            WiCANReportingBinarySensorEntity(
+                config_entry, REPORTING_BINARY_SENSOR_DESCRIPTION, stale_timeout,
+            ),
+        ],
     )
 
 class WiCANBinarySensorEntity(WiCANEntity, BinarySensorEntity, RestoreEntity):
@@ -81,3 +102,92 @@ class WiCANBinarySensorEntity(WiCANEntity, BinarySensorEntity, RestoreEntity):
         if last_state is not None and self._attr_is_on is None:
             self._attr_is_on = last_state.state == "on"
         await super().async_added_to_hass()
+
+
+class WiCANReportingBinarySensorEntity(WiCANEntity, BinarySensorEntity, RestoreEntity):
+    """Whether the device has pushed data within its expected interval.
+
+    WiCAN is push-only, and on many installs only reachable while parked at
+    home on Wi-Fi (e.g. a WiCAN wired to a switched 12V pin). Once the
+    vehicle leaves, every other sensor here just keeps its last reported
+    value forever - CoordinatorEntity availability never reflects that,
+    since the push-based coordinator's own fallback poll always succeeds
+    with cached data (see WiCANDataUpdateCoordinator._async_update_data).
+    This is the "is the rest of this device's data fresh" signal those
+    sensors don't provide on their own.
+    """
+
+    __slots__ = ("_timeout", "_unsub_stale")
+
+    def __init__(self, config_entry, entity_description, timeout: float) -> None:
+        super().__init__(config_entry, entity_description)
+        self._attr_unique_id = f"{config_entry.entry_id}_{entity_description.key}"
+        self._attr_is_on = None
+        self._timeout = timeout
+        self._unsub_stale: CALLBACK_TYPE | None = None
+
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator.
+
+        Recomputed from last_webhook_time rather than treating every call
+        as "a push just arrived": some Home Assistant builds also invoke
+        this once when the entity is (re)added, before any push has
+        happened this session, which would otherwise mark it on regardless
+        of how stale the device actually is.
+        """
+        self._refresh_from_last_webhook()
+
+    def _refresh_from_last_webhook(self) -> None:
+        last = self.coordinator.last_webhook_time
+        if last is None:
+            # Nothing received yet this session - leave any restored value
+            # alone rather than fabricating a state from nothing.
+            self.async_write_ha_state()
+            return
+
+        age = (dt_util.utcnow() - last).total_seconds()
+        if age < self._timeout:
+            self._attr_is_on = True
+            self._arm_stale_timer(self._timeout - age)
+        else:
+            self._attr_is_on = False
+        self.async_write_ha_state()
+
+    def _arm_stale_timer(self, delay: float) -> None:
+        if self._unsub_stale is not None:
+            self._unsub_stale()
+            self._unsub_stale = None
+        if delay > 0:
+            self._unsub_stale = async_call_later(
+                self.hass, delay, self._handle_stale_timeout,
+            )
+
+    @callback
+    def _handle_stale_timeout(self, _now) -> None:
+        self._unsub_stale = None
+        self._attr_is_on = False
+        self.async_write_ha_state()
+
+    @callback
+    def _async_handle_event(self, webhook_id: str, data) -> None:
+        """Handle webhook event (backward compatibility)."""
+        # Coordinator update will trigger _handle_coordinator_update()
+
+    async def async_added_to_hass(self) -> None:
+        """Restore entity state."""
+        last_state = await self.async_get_last_state()
+        if last_state is not None and self._attr_is_on is None:
+            self._attr_is_on = last_state.state == "on"
+        await super().async_added_to_hass()
+        if self._unsub_stale is None:
+            # Nothing armed a timer above (no push has arrived this
+            # session) - a restored "on" needs one anyway, or it would
+            # never go stale if the device never reports again.
+            self._arm_stale_timer(self._timeout)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Cancel any pending stale-check timer."""
+        if self._unsub_stale is not None:
+            self._unsub_stale()
+            self._unsub_stale = None
+        await super().async_will_remove_from_hass()

--- a/custom_components/wican/const.py
+++ b/custom_components/wican/const.py
@@ -45,3 +45,10 @@ GITHUB_RELEASES_UPDATE_INTERVAL = 3600  # 1 hour
 
 # WiCAN Data Coordinator (push-based fallback polling)
 WICAN_DATA_UPDATE_INTERVAL = 300  # seconds (5 minutes)
+
+# "Reporting" binary sensor: how long to wait after the last webhook push
+# before considering the device's data stale, relative to its own post
+# interval. Floored so a short post_interval (e.g. 1s, for testing) doesn't
+# make the sensor flap on ordinary network jitter.
+REPORTING_STALE_MULTIPLIER = 3
+REPORTING_MIN_TIMEOUT = 120  # seconds

--- a/custom_components/wican/coordinator.py
+++ b/custom_components/wican/coordinator.py
@@ -8,10 +8,13 @@ from typing import TYPE_CHECKING, Any
 
 from homeassistant.exceptions import ConfigEntryError
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN, WICAN_DATA_UPDATE_INTERVAL
 
 if TYPE_CHECKING:
+    from datetime import datetime
+
     from homeassistant.core import HomeAssistant
 
     from . import WiCANConfigEntry
@@ -34,6 +37,12 @@ class WiCANDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Initialize the coordinator."""
         self.config_entry = config_entry
         self._data: dict[str, Any] = {}
+        # When the device last actually pushed data, as opposed to
+        # last_update_success which this push-based coordinator sets True
+        # once and never re-evaluates. Entities use this to tell a fresh
+        # reading from one the device hasn't refreshed since - e.g. one
+        # that only reports while parked at home on Wi-Fi.
+        self.last_webhook_time: datetime | None = None
 
         super().__init__(
             hass,
@@ -78,6 +87,7 @@ class WiCANDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         # Update internal data store
         self._data.update(data)
+        self.last_webhook_time = dt_util.utcnow()
 
         # Notify all entities that data has been updated
         self.async_set_updated_data(self._data)

--- a/custom_components/wican/translations/en.json
+++ b/custom_components/wican/translations/en.json
@@ -49,6 +49,9 @@
         },
         "ecu_status": {
           "name": "ECU Online"
+        },
+        "reporting": {
+          "name": "Reporting"
         }
       },
       "device_tracker": {

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -249,3 +249,141 @@ async def test_binary_sensor_none_checks(hass: HomeAssistant, hass_client) -> No
     # Verify entities exist and didn't crash
     state = hass.states.get("binary_sensor.wican_test_ble_status")
     assert state is not None
+
+
+async def test_reporting_sensor_created(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+) -> None:
+    """The Reporting sensor is created alongside the other binary sensors."""
+    entity_registry = er.async_get(hass)
+
+    reporting = entity_registry.async_get("binary_sensor.wican_device_reporting")
+    assert reporting is not None
+    assert reporting.unique_id.endswith("_reporting")
+
+    state = hass.states.get("binary_sensor.wican_device_reporting")
+    assert state is not None
+    assert state.attributes.get("device_class") == "connectivity"
+
+
+async def test_reporting_sensor_unknown_before_first_webhook(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+) -> None:
+    """No webhook has arrived yet, so there's nothing to report freshness on."""
+    state = hass.states.get("binary_sensor.wican_device_reporting")
+    assert state is not None
+    assert state.state == "unknown"
+
+
+async def test_reporting_sensor_on_after_webhook(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_webhook_data: dict,
+    hass_client,
+) -> None:
+    """A webhook push marks the device as reporting."""
+    entry = init_integration
+    client = await hass_client()
+
+    await client.post(f"/api/webhook/{entry.data[CONF_WEBHOOK_ID]}", json=mock_webhook_data)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.wican_device_reporting")
+    assert state.state == STATE_ON
+
+
+async def test_reporting_sensor_goes_stale_after_timeout(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_webhook_data: dict,
+    hass_client,
+) -> None:
+    """No further pushes within the timeout flips the sensor off.
+
+    The timeout is normally minutes long (see REPORTING_MIN_TIMEOUT), so this
+    patches it down to a fraction of a second rather than simulating time
+    passing: the stale check is armed via async_call_later, which schedules
+    against the event loop's own monotonic clock and isn't moved by
+    async_fire_time_changed (that only affects wall-clock-based trackers).
+    """
+    import asyncio
+
+    with (
+        patch("custom_components.wican.binary_sensor.REPORTING_STALE_MULTIPLIER", 0),
+        patch("custom_components.wican.binary_sensor.REPORTING_MIN_TIMEOUT", 0.1),
+        patch(
+            "custom_components.wican._async_register_webhook_on_device",
+            return_value=True,
+        ),
+    ):
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        client = await hass_client()
+        await client.post(
+            f"/api/webhook/{mock_config_entry.data[CONF_WEBHOOK_ID]}",
+            json=mock_webhook_data,
+        )
+        await hass.async_block_till_done()
+        assert hass.states.get("binary_sensor.wican_device_reporting").state == STATE_ON
+
+        await asyncio.sleep(0.3)
+        await hass.async_block_till_done()
+
+    assert hass.states.get("binary_sensor.wican_device_reporting").state == STATE_OFF
+
+
+async def test_reporting_sensor_restored_state_still_goes_stale(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_webhook_data: dict,
+    hass_client,
+) -> None:
+    """A restored "on" state still gets its own stale-check timer armed.
+
+    Without this, an entity restored as "on" after a Home Assistant restart
+    would stay "on" forever if the device never reports again - nothing
+    would be left to flip it off, since the new session's coordinator has no
+    last_webhook_time of its own yet to recompute freshness from.
+    """
+    import asyncio
+
+    with patch(
+        "custom_components.wican._async_register_webhook_on_device",
+        return_value=True,
+    ):
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        client = await hass_client()
+        await client.post(
+            f"/api/webhook/{mock_config_entry.data[CONF_WEBHOOK_ID]}",
+            json=mock_webhook_data,
+        )
+        await hass.async_block_till_done()
+        assert hass.states.get("binary_sensor.wican_device_reporting").state == STATE_ON
+
+        await hass.config_entries.async_unload(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    with (
+        patch("custom_components.wican.binary_sensor.REPORTING_STALE_MULTIPLIER", 0),
+        patch("custom_components.wican.binary_sensor.REPORTING_MIN_TIMEOUT", 0.1),
+        patch(
+            "custom_components.wican._async_register_webhook_on_device",
+            return_value=True,
+        ),
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert hass.states.get("binary_sensor.wican_device_reporting").state == STATE_ON
+
+        await asyncio.sleep(0.3)
+        await hass.async_block_till_done()
+
+    assert hass.states.get("binary_sensor.wican_device_reporting").state == STATE_OFF

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -116,6 +116,25 @@ async def test_coordinator_device_identity_validation_no_device_id(
     assert coordinator.data == no_device_id_data
 
 
+async def test_coordinator_tracks_last_webhook_time(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_webhook_data: dict,
+) -> None:
+    """Test the coordinator records when a webhook was last handled."""
+    coordinator = WiCANDataUpdateCoordinator(hass, mock_config_entry)
+    await coordinator.async_config_entry_first_refresh()
+
+    assert coordinator.last_webhook_time is None
+
+    before = dt_util.utcnow()
+    coordinator.handle_webhook_data(mock_webhook_data)
+    after = dt_util.utcnow()
+
+    assert coordinator.last_webhook_time is not None
+    assert before <= coordinator.last_webhook_time <= after
+
+
 async def test_coordinator_normalize_sensor_value_voltage(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,


### PR DESCRIPTION
WiCAN pushes data over a webhook and is often only reachable while parked at home on Wi-Fi (e.g. wired to a switched 12V pin). Once the car leaves, every other sensor here just keeps its last reported value forever - including ecu_status, which stays "on" long after the device has gone quiet - with nothing to show the data has gone stale.

Track the coordinator's last webhook time and expose a "Reporting" connectivity binary sensor that flips off if no push arrives within a timeout derived from the configured post interval, so the rest of the device's sensors can be read alongside a real freshness signal instead of CoordinatorEntity availability, which this push-based integration never lets go false.