### PR TITLE
Stop trusting X-Forwarded-For on the webhook endpoint

### DIFF
--- a/custom_components/wican/__init__.py
+++ b/custom_components/wican/__init__.py
@@ -170,23 +170,19 @@ def _normalize_ip(ip: str | None) -> str | None:
 
 
 def _extract_request_ip(request: Request) -> str | None:
-    """Best-effort extraction of the originating peer IP address."""
-    forwarded_for = request.headers.get("X-Forwarded-For")
-    if forwarded_for:
-        first = forwarded_for.split(",")[0].strip()
-        if first:
-            return _normalize_ip(first)
+    """Return the IP the webhook request came from.
 
-    transport = request.transport
-    if transport is not None:
-        peername = transport.get_extra_info("peername")
-        if isinstance(peername, (tuple, list)) and peername:
-            return _normalize_ip(peername[0])
+    request.remote is the only trustworthy source. Home Assistant's forwarded
+    middleware already resolves X-Forwarded-For into it, but only when the
+    operator has set use_x_forwarded_for together with trusted_proxies -
+    reading the header here instead would accept it from anyone.
 
-    if request.remote:
-        return _normalize_ip(request.remote)
-
-    return None
+    That matters because this address is stored on the config entry and the
+    integration then POSTs the webhook registration, which carries the webhook
+    URL, to it. Honouring an unvalidated header would let any client that can
+    reach the webhook endpoint redirect that request to a host of its choosing.
+    """
+    return _normalize_ip(request.remote)
 
 
 async def async_setup_entry(  # noqa: C901, PLR0915
@@ -277,6 +273,20 @@ async def async_setup_entry(  # noqa: C901, PLR0915
                 text=error.error_message, status=HTTPStatus.UNPROCESSABLE_ENTITY,
             )
 
+        # Update coordinator with new data.
+        # This runs before anything is persisted: it rejects a payload whose
+        # device_id does not match the configured device, and the connection
+        # info below is only trustworthy once that has passed.
+        try:
+            coordinator.handle_webhook_data(data)
+        except ConfigEntryError:
+            # Device identity mismatch - log error and reject webhook
+            _LOGGER.exception("Rejecting webhook due to device identity validation failure")
+            return Response(
+                text="Device identity mismatch",
+                status=HTTPStatus.FORBIDDEN,
+            )
+
         # Extract device info fields from top-level or nested "status"
         device_info_fields = {}
         status = data.get("status", {})
@@ -328,17 +338,6 @@ async def async_setup_entry(  # noqa: C901, PLR0915
                     hass.async_create_task(
                         _async_register_webhook_on_device(hass, entry),
                     )
-
-        # Update coordinator with new data
-        try:
-            coordinator.handle_webhook_data(data)
-        except ConfigEntryError:
-            # Device identity mismatch - log error and reject webhook
-            _LOGGER.exception("Rejecting webhook due to device identity validation failure")
-            return Response(
-                text="Device identity mismatch",
-                status=HTTPStatus.FORBIDDEN,
-            )
 
         # Keep dispatcher for backward compatibility during migration
         async_dispatcher_send(hass, DOMAIN, webhook_id, data)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -116,8 +116,75 @@ async def test_webhook_device_identity_mismatch(
         json=wrong_device_data,
     )
 
-    # Integration accepts data from any device on this webhook (doesn't validate device_id)
+    # The coordinator validates device_id and the handler turns the resulting
+    # ConfigEntryError into a 403
+    assert resp.status == 403
+
+
+async def test_webhook_identity_mismatch_does_not_persist_connection_info(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    hass_client,
+) -> None:
+    """A rejected payload must not move the device address.
+
+    The stored address is where the integration POSTs the webhook
+    registration, which carries the webhook URL. Connection info used to be
+    written - and a re-registration scheduled against it - before the
+    device_id was checked, so a rejected payload could still redirect it.
+    """
+    entry = init_integration
+    original_ip = entry.data.get("ip")
+    original_host = entry.data.get("host")
+
+    client = await hass_client()
+
+    with patch(
+        "custom_components.wican._async_register_webhook_on_device",
+        AsyncMock(return_value=True),
+    ) as mock_register:
+        resp = await client.post(
+            f"/api/webhook/{entry.data[CONF_WEBHOOK_ID]}",
+            json={
+                "status": {
+                    "device_id": "different_device_456",
+                    "host": "http://198.51.100.9",
+                    "ip": "198.51.100.9",
+                },
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert resp.status == 403
+    assert entry.data.get("ip") == original_ip
+    assert entry.data.get("host") == original_host
+    mock_register.assert_not_called()
+
+
+async def test_webhook_from_configured_device_persists_source_ip(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_webhook_data: dict,
+    hass_client,
+) -> None:
+    """A payload from the configured device still records where it came from."""
+    entry = init_integration
+
+    client = await hass_client()
+
+    with patch(
+        "custom_components.wican._async_register_webhook_on_device",
+        AsyncMock(return_value=True),
+    ):
+        resp = await client.post(
+            f"/api/webhook/{entry.data[CONF_WEBHOOK_ID]}",
+            json=mock_webhook_data,
+        )
+        await hass.async_block_till_done()
+
     assert resp.status == 204
+    # hass_client connects over loopback
+    assert entry.data.get("ip") == "127.0.0.1"
 
 
 async def test_entry_updated(

--- a/tests/test_init_helpers.py
+++ b/tests/test_init_helpers.py
@@ -163,101 +163,61 @@ def test_normalize_ip_ipv4_mapped_alternate():
     assert _normalize_ip("::ffff:c0a8:0164") == "c0a8:0164"
 
 
-def test_extract_request_ip_from_x_forwarded_for():
-    """Test _extract_request_ip with X-Forwarded-For header."""
-    request = MagicMock(spec=Request)
-    request.headers.get.return_value = "203.0.113.1, 198.51.100.1"
-    request.transport = None
-    request.remote = None
-    
-    result = _extract_request_ip(request)
-    assert result == "203.0.113.1"
-
-
-def test_extract_request_ip_from_x_forwarded_for_with_ipv6():
-    """Test _extract_request_ip with X-Forwarded-For containing IPv6."""
-    request = MagicMock(spec=Request)
-    request.headers.get.return_value = "::ffff:192.168.1.1, 198.51.100.1"
-    request.transport = None
-    request.remote = None
-    
-    result = _extract_request_ip(request)
-    assert result == "192.168.1.1"
-
-
-def test_extract_request_ip_from_transport():
-    """Test _extract_request_ip from transport peername."""
-    request = MagicMock(spec=Request)
-    request.headers.get.return_value = None
-    
-    transport = MagicMock()
-    transport.get_extra_info.return_value = ("192.168.1.50", 12345)
-    request.transport = transport
-    request.remote = None
-    
-    result = _extract_request_ip(request)
-    assert result == "192.168.1.50"
-
-
-def test_extract_request_ip_from_transport_ipv6():
-    """Test _extract_request_ip from transport with IPv6."""
-    request = MagicMock(spec=Request)
-    request.headers.get.return_value = None
-    
-    transport = MagicMock()
-    transport.get_extra_info.return_value = ("::ffff:10.0.0.1", 54321)
-    request.transport = transport
-    request.remote = None
-    
-    result = _extract_request_ip(request)
-    assert result == "10.0.0.1"
-
-
 def test_extract_request_ip_from_remote():
     """Test _extract_request_ip from request.remote."""
     request = MagicMock(spec=Request)
-    request.headers.get.return_value = None
-    request.transport = None
+    request.headers = {}
     request.remote = "172.16.0.1"
-    
+
     result = _extract_request_ip(request)
     assert result == "172.16.0.1"
+
+
+def test_extract_request_ip_normalizes_ipv4_mapped_remote():
+    """Test _extract_request_ip normalizes an IPv4-mapped IPv6 remote."""
+    request = MagicMock(spec=Request)
+    request.headers = {}
+    request.remote = "::ffff:10.0.0.1"
+
+    result = _extract_request_ip(request)
+    assert result == "10.0.0.1"
 
 
 def test_extract_request_ip_no_ip_found():
     """Test _extract_request_ip when no IP is available."""
     request = MagicMock(spec=Request)
-    request.headers.get.return_value = None
-    request.transport = None
+    request.headers = {}
     request.remote = None
-    
+
     result = _extract_request_ip(request)
     assert result is None
 
 
-def test_extract_request_ip_transport_no_peername():
-    """Test _extract_request_ip when transport has no peername."""
+def test_extract_request_ip_ignores_x_forwarded_for():
+    """An untrusted X-Forwarded-For must not override the peer address.
+
+    The stored IP is where the integration POSTs the webhook registration,
+    which carries the webhook URL. Home Assistant resolves X-Forwarded-For
+    into request.remote itself, but only when the operator configured
+    use_x_forwarded_for with trusted_proxies; honouring the raw header would
+    let any client that can reach the webhook redirect that POST.
+    """
     request = MagicMock(spec=Request)
-    request.headers.get.return_value = None
-    
-    transport = MagicMock()
-    transport.get_extra_info.return_value = None
-    request.transport = transport
-    request.remote = "10.0.0.5"
-    
+    request.headers = {"X-Forwarded-For": "203.0.113.1, 198.51.100.1"}
+    request.remote = "192.168.1.50"
+
     result = _extract_request_ip(request)
-    assert result == "10.0.0.5"
+    assert result == "192.168.1.50"
 
 
-def test_extract_request_ip_transport_empty_peername():
-    """Test _extract_request_ip when peername is empty."""
+def test_extract_request_ip_ignores_transport_peername():
+    """The raw transport bypasses the forwarded middleware, so it is not used."""
     request = MagicMock(spec=Request)
-    request.headers.get.return_value = None
-    
+    request.headers = {}
     transport = MagicMock()
-    transport.get_extra_info.return_value = []
+    transport.get_extra_info.return_value = ("198.51.100.9", 12345)
     request.transport = transport
-    request.remote = "10.0.0.6"
-    
+    request.remote = "192.168.1.50"
+
     result = _extract_request_ip(request)
-    assert result == "10.0.0.6"
+    assert result == "192.168.1.50"


### PR DESCRIPTION
_extract_request_ip() read X-Forwarded-For from any caller. Home Assistant strips that header unless the operator sets use_x_forwarded_for together with trusted_proxies, so this re-added what HA had deliberately removed, without the trust check that makes it safe.

The address it produces is stored on the config entry as the device address, and because "ip" counts as a connection field, changing it schedules _async_register_webhook_on_device(), which POSTs the webhook URL to that address. Any client that could reach the webhook endpoint could therefore hand the webhook URL - a bearer credential for injecting sensor data - to a host of its choosing, aim a blind SSRF at anything reachable from the HA container, or simply point the integration at a dead address so the real device's updates stopped being registered.

Use request.remote, which HA's forwarded middleware has already resolved from X-Forwarded-For when, and only when, the operator configured it. The transport peername fallback goes too: it bypasses that middleware, and aiohttp derives request.remote from the same peername anyway.

Also validate the device identity before persisting anything. The connection info was written, and the re-registration scheduled, before handle_webhook_data() checked device_id, so a payload that was about to be rejected with a 403 had already moved the stored address. An attacker now needs the device_id as well as the webhook id.

test_webhook_device_identity_mismatch asserted a 204 with a comment saying the integration does not validate device_id. It has validated it since the coordinator gained _validate_device_identity(); corrected to 403.