### PR TITLE
Don't create the device tracker for hardware that never reports GPS

### DIFF
--- a/custom_components/wican/device_tracker.py
+++ b/custom_components/wican/device_tracker.py
@@ -27,9 +27,34 @@ _LOGGER = logging.getLogger(__name__)
 # Entity will be named "WiCAN Device Location" with has_entity_name=True
 TRACKER_NAME = "Location"
 
+# hw_version substrings for models no current firmware sends a "gps" block
+# for. WiCAN-PRO is the only model sold with a GPS module; unrecognized or
+# missing hw_version keeps the previous always-create behaviour rather than
+# guessing.
+_NO_GPS_HARDWARE_MARKERS = ("obd", "usb")
+
+# Persisted once a device proves it can report a fix, so a firmware update
+# that adds GPS to a model this integration otherwise assumes can't isn't
+# permanently missing a tracker.
+CONF_HAS_REPORTED_GPS = "has_reported_gps"
+
+
+def _supports_location(config_entry: WiCANConfigEntry) -> bool:
+    """Return whether this device is expected to ever report GPS.
+
+    Creating the tracker unconditionally left it permanently "unknown" on
+    WiCAN-OBD/-USB hardware: no current firmware build populates the
+    webhook's "gps" key on those models, only WiCAN-PRO ships a GPS module.
+    """
+    if config_entry.data.get(CONF_HAS_REPORTED_GPS):
+        return True
+
+    hw_version = str(config_entry.data.get("hw_version", "")).lower()
+    return not any(marker in hw_version for marker in _NO_GPS_HARDWARE_MARKERS)
+
 
 async def async_setup_entry(
-    _hass: HomeAssistant,
+    hass: HomeAssistant,
     config_entry: WiCANConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
@@ -38,12 +63,38 @@ async def async_setup_entry(
     Creates a single device_tracker entity that represents the GPS location
     of the WiCAN device (typically mounted in a vehicle).
     """
+    if _supports_location(config_entry):
+        async_add_entities([WiCANDeviceTrackerEntity(config_entry)])
+        _LOGGER.debug("Device tracker entity created for %s", config_entry.title)
+        return
 
-    # Always create the tracker entity - it will show as unavailable if no GPS data
-    entity = WiCANDeviceTrackerEntity(config_entry)
-    async_add_entities([entity])
+    _LOGGER.debug(
+        "Skipping device tracker for %s (hw_version=%s has no GPS)",
+        config_entry.title,
+        config_entry.data.get("hw_version"),
+    )
 
-    _LOGGER.debug("Device tracker entity created for %s", config_entry.title)
+    coordinator = config_entry.runtime_data.coordinator
+
+    @callback
+    def _create_tracker_on_first_fix() -> None:
+        gps_data = coordinator.data.get("gps", {}) if coordinator.data else {}
+        if gps_data.get("latitude") is None or gps_data.get("longitude") is None:
+            return
+
+        unsub()
+        new_data = dict(config_entry.data)
+        new_data[CONF_HAS_REPORTED_GPS] = True
+        hass.config_entries.async_update_entry(config_entry, data=new_data)
+
+        async_add_entities([WiCANDeviceTrackerEntity(config_entry)])
+        _LOGGER.debug(
+            "First GPS fix received from %s; device tracker created",
+            config_entry.title,
+        )
+
+    unsub = coordinator.async_add_listener(_create_tracker_on_first_fix)
+    config_entry.async_on_unload(unsub)
 
 
 class WiCANDeviceTrackerEntity(CoordinatorEntity, TrackerEntity, RestoreEntity):

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -6,13 +6,14 @@ import pytest
 from unittest.mock import patch
 
 from homeassistant.components.device_tracker import SourceType
-from homeassistant.const import STATE_HOME, STATE_NOT_HOME, STATE_UNAVAILABLE
+from homeassistant.const import CONF_WEBHOOK_ID, STATE_HOME, STATE_NOT_HOME, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.wican.const import DOMAIN
+from custom_components.wican.device_tracker import CONF_HAS_REPORTED_GPS
 
 
 @pytest.fixture
@@ -387,3 +388,113 @@ async def test_device_tracker_gps_parse_error_logging(
     entity_id = "device_tracker.wican_device_location"
     state = hass.states.get(entity_id)
     assert state.state == STATE_UNAVAILABLE
+
+
+def _obd_config_entry(**extra_data) -> MockConfigEntry:
+    """Build a config entry for hardware known not to report GPS."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="WiCAN Device",
+        data={
+            "mdns": "http://wican_test.local:80",
+            CONF_WEBHOOK_ID: "test_webhook_id",
+            "fw_version": "4.21",
+            "hw_version": "WiCAN-OBD",
+            "device_id": "test_device_123",
+            **extra_data,
+        },
+        unique_id="wican_test-obd",
+    )
+
+
+async def test_device_tracker_not_created_for_gps_less_hardware(
+    hass: HomeAssistant,
+) -> None:
+    """No tracker is created for hardware that never reports a GPS block.
+
+    WiCAN-OBD/-USB firmware never populates the webhook's "gps" key, so
+    creating the entity unconditionally left it permanently "unknown" -
+    indistinguishable from a real device that has gone offline.
+    """
+    entry = _obd_config_entry()
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.wican._async_register_webhook_on_device",
+        return_value=True,
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert hass.states.get("device_tracker.wican_device_location") is None
+
+
+async def test_device_tracker_created_for_pro_hardware(
+    hass: HomeAssistant,
+) -> None:
+    """WiCAN-PRO ships a GPS module, so the tracker is still created eagerly."""
+    entry = _obd_config_entry(**{"hw_version": "WiCAN-PRO"})
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.wican._async_register_webhook_on_device",
+        return_value=True,
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert hass.states.get("device_tracker.wican_device_location") is not None
+
+
+async def test_device_tracker_created_lazily_after_first_gps_fix(
+    hass: HomeAssistant,
+    mock_gps_data: dict,
+    hass_client,
+) -> None:
+    """A device that proves it can report GPS gets the tracker after all."""
+    entry = _obd_config_entry()
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.wican._async_register_webhook_on_device",
+        return_value=True,
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert hass.states.get("device_tracker.wican_device_location") is None
+
+    client = await hass_client()
+    await client.post(f"/api/webhook/{entry.data[CONF_WEBHOOK_ID]}", json=mock_gps_data)
+    await hass.async_block_till_done()
+
+    # The tracker exists now, and the config entry remembers this device can
+    # report GPS so it's created eagerly on every future startup.
+    assert hass.states.get("device_tracker.wican_device_location") is not None
+    assert entry.data.get(CONF_HAS_REPORTED_GPS) is True
+
+    # It missed the payload that triggered its own creation - the next fix
+    # populates its coordinates.
+    await client.post(f"/api/webhook/{entry.data[CONF_WEBHOOK_ID]}", json=mock_gps_data)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("device_tracker.wican_device_location")
+    assert state.attributes["latitude"] == 37.7749
+    assert state.attributes["longitude"] == -122.4194
+
+
+async def test_device_tracker_created_eagerly_once_gps_seen_before(
+    hass: HomeAssistant,
+) -> None:
+    """A device that has proven it reports GPS skips the lazy wait."""
+    entry = _obd_config_entry(**{CONF_HAS_REPORTED_GPS: True})
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.wican._async_register_webhook_on_device",
+        return_value=True,
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert hass.states.get("device_tracker.wican_device_location") is not None


### PR DESCRIPTION
No current WiCAN-OBD or WiCAN-USB firmware ever populates the webhook's
"gps" key - only WiCAN-PRO ships a GPS module. Creating the tracker
unconditionally left it permanently "unknown" on the more common
hardware, indistinguishable from a tracker that's actually broken.