### PR TITLE
Ask a manually added device for its device_id

### DIFF
--- a/custom_components/wican/config_flow.py
+++ b/custom_components/wican/config_flow.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
+from http import HTTPStatus
 import logging
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
+import aiohttp
 from homeassistant import config_entries
 from homeassistant.components import onboarding
 from homeassistant.const import CONF_HOST, CONF_WEBHOOK_ID
 from homeassistant.core import callback
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import voluptuous as vol
 from yarl import URL
 
@@ -25,10 +28,15 @@ from .helpers import resolve_webhook_url
 if TYPE_CHECKING:
     from ipaddress import IPv4Address, IPv6Address
 
+    from homeassistant.core import HomeAssistant
     from homeassistant.data_entry_flow import FlowResult
     from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 _LOGGER = logging.getLogger(__name__)
+
+# The device is on the local network, so a status request either answers
+# immediately or is not going to answer at all.
+STATUS_TIMEOUT = aiohttp.ClientTimeout(total=5)
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -64,6 +72,20 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 entry_data["mdns"] = _format_http_url(mdns, None) or mdns
             if host:
                 entry_data["host"] = _format_http_url(host, None) or host
+
+            # Ask the device who it is before creating the entry. Without a
+            # device_id the device registry keys the device on the config entry
+            # id; the first webhook then supplies the real device_id and the
+            # entities move to a second device, leaving the first one orphaned.
+            device_id = await _fetch_device_id(
+                self.hass,
+                entry_data.get("host"),
+                entry_data.get("mdns"),
+            )
+            if device_id:
+                entry_data["device_id"] = device_id
+                await self.async_set_unique_id(device_id)
+                self._abort_if_unique_id_configured()
 
             return self.async_create_entry(
                 title=title,
@@ -211,6 +233,41 @@ class WiCANOptionsFlow(config_entries.OptionsFlow):
             },
         )
         return self.async_show_form(step_id="init", data_schema=data_schema)
+
+
+async def _fetch_device_id(hass: HomeAssistant, *urls: str | None) -> str | None:
+    """Read the device_id a WiCAN reports on its /status endpoint.
+
+    Args:
+        hass: The Home Assistant instance.
+        urls: Base URLs to try, in order, until one answers.
+
+    Returns:
+        The reported device_id, or None if no URL answered with one.
+    """
+    session = async_get_clientsession(hass)
+    for url in urls:
+        if not url:
+            continue
+
+        status_url = f"{url.rstrip('/')}/status"
+        try:
+            async with session.get(status_url, timeout=STATUS_TIMEOUT) as response:
+                if response.status != HTTPStatus.OK:
+                    _LOGGER.debug("Status request to %s returned HTTP %s", status_url, response.status)
+                    continue
+                status = await response.json(content_type=None)
+        except (TimeoutError, aiohttp.ClientError, ValueError) as err:
+            _LOGGER.debug("Could not read device_id from %s: %s", status_url, err)
+            continue
+
+        device_id = status.get("device_id") if isinstance(status, dict) else None
+        if device_id:
+            return str(device_id)
+
+        _LOGGER.debug("No device_id in the status reported by %s", status_url)
+
+    return None
 
 
 def _format_http_url(address: str | None, port: int | None) -> str | None:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import aiohttp
 import pytest
 
 from homeassistant import config_entries
@@ -15,6 +17,42 @@ from homeassistant.const import CONF_NAME, CONF_WEBHOOK_ID
 from custom_components.wican.const import DOMAIN
 
 from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+
+def _status_session(
+    *,
+    device_id: str | None = None,
+    error: Exception | None = None,
+) -> MagicMock:
+    """Return a mock client session answering the WiCAN /status endpoint."""
+    session = MagicMock()
+    if error is not None:
+        session.get = MagicMock(side_effect=error)
+        return session
+
+    response = MagicMock()
+    response.status = 200
+    response.json = AsyncMock(
+        return_value={"device_id": device_id} if device_id else {},
+    )
+    request = MagicMock()
+    request.__aenter__ = AsyncMock(return_value=response)
+    request.__aexit__ = AsyncMock(return_value=False)
+    session.get = MagicMock(return_value=request)
+    return session
+
+
+@pytest.fixture(autouse=True)
+def mock_status_unreachable() -> Generator[MagicMock]:
+    """Make the manual flow's status request fail unless a test says otherwise."""
+    with patch(
+        "custom_components.wican.config_flow.async_get_clientsession",
+        return_value=_status_session(error=aiohttp.ClientError("unreachable")),
+    ) as mock_session:
+        yield mock_session
 
 
 async def test_user_flow_success(
@@ -81,6 +119,81 @@ async def test_user_flow_adds_http_scheme(
 
     assert result2["type"] == FlowResultType.CREATE_ENTRY
     assert result2["data"]["mdns"] == "http://wican_test.local"
+
+
+async def test_user_flow_fetches_device_id(hass: HomeAssistant) -> None:
+    """Test the manual flow stores the device_id the device reports."""
+    session = _status_session(device_id="abc123")
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+    )
+
+    with (
+        patch(
+            "custom_components.wican.config_flow.async_get_clientsession",
+            return_value=session,
+        ),
+        patch("custom_components.wican.async_setup_entry", return_value=True),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"mdns": "wican_test.local", "host": "192.168.1.50"},
+        )
+
+    await hass.async_block_till_done()
+
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["data"]["device_id"] == "abc123"
+    assert result2["result"].unique_id == "abc123"
+    # The host is the more reliable address, so it is tried first.
+    assert session.get.call_args.args[0] == "http://192.168.1.50/status"
+
+
+async def test_user_flow_status_unreachable(hass: HomeAssistant) -> None:
+    """Test the manual flow still creates the entry when /status does not answer."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+    )
+
+    with patch("custom_components.wican.async_setup_entry", return_value=True):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"mdns": "wican_test.local"},
+        )
+
+    await hass.async_block_till_done()
+
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert "device_id" not in result2["data"]
+    assert result2["result"].unique_id is None
+
+
+async def test_user_flow_duplicate_device_id_aborts(hass: HomeAssistant) -> None:
+    """Test the manual flow aborts when the device is already configured."""
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="abc123",
+        data={CONF_WEBHOOK_ID: "existing", "device_id": "abc123"},
+    ).add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+    )
+
+    with patch(
+        "custom_components.wican.config_flow.async_get_clientsession",
+        return_value=_status_session(device_id="abc123"),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"mdns": "wican_test.local"},
+        )
+
+    assert result2["type"] == FlowResultType.ABORT
+    assert result2["reason"] == "already_configured"
 
 
 async def test_zeroconf_flow_success(


### PR DESCRIPTION
A device added by IP or hostname ends up registered twice.  The manual step stores only the webhook id and the address, so build_device_info() falls back to the config entry id as the device identifier.  The first webhook then carries the real device_id, which __init__ writes to the entry data, and build_device_info() starts returning a different identifier: Home Assistant registers a second device for it and the original is left behind, named after the IP, holding a stale location entity.

The manual step now reads /status before creating the entry, the same device_id the zeroconf step takes from the mDNS TXT records, so the identifier is stable from the first entity onwards.  The host is tried before the mDNS name because it does not depend on mDNS resolution working.  A device that does not answer still gets an entry, exactly as before; it just keeps the old behaviour of learning its identity from the first webhook.

Knowing the device_id also lets the flow abort when that device is already configured.  This does not catch a device discovered over zeroconf, since those entries prefer the MAC address as their unique id.