### PR TITLE
Recognize a device that was added through the other flow

### DIFF
--- a/custom_components/wican/config_flow.py
+++ b/custom_components/wican/config_flow.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
+from http import HTTPStatus
 import logging
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
+import aiohttp
 from homeassistant import config_entries
 from homeassistant.components import onboarding
 from homeassistant.const import CONF_HOST, CONF_WEBHOOK_ID
 from homeassistant.core import callback
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import voluptuous as vol
 from yarl import URL
 
@@ -25,10 +28,15 @@ from .helpers import resolve_webhook_url
 if TYPE_CHECKING:
     from ipaddress import IPv4Address, IPv6Address
 
+    from homeassistant.core import HomeAssistant
     from homeassistant.data_entry_flow import FlowResult
     from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 _LOGGER = logging.getLogger(__name__)
+
+# The device is on the local network, so a status request either answers
+# immediately or is not going to answer at all.
+STATUS_TIMEOUT = aiohttp.ClientTimeout(total=5)
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -64,6 +72,20 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 entry_data["mdns"] = _format_http_url(mdns, None) or mdns
             if host:
                 entry_data["host"] = _format_http_url(host, None) or host
+
+            # Ask the device who it is before creating the entry. Without a
+            # device_id the device registry keys the device on the config entry
+            # id; the first webhook then supplies the real device_id and the
+            # entities move to a second device, leaving the first one orphaned.
+            device_id = await _fetch_device_id(
+                self.hass,
+                entry_data.get("host"),
+                entry_data.get("mdns"),
+            )
+            if device_id:
+                entry_data["device_id"] = device_id
+                await self.async_set_unique_id(device_id)
+                self._abort_if_unique_id_configured()
 
             return self.async_create_entry(
                 title=title,
@@ -211,6 +233,41 @@ class WiCANOptionsFlow(config_entries.OptionsFlow):
             },
         )
         return self.async_show_form(step_id="init", data_schema=data_schema)
+
+
+async def _fetch_device_id(hass: HomeAssistant, *urls: str | None) -> str | None:
+    """Read the device_id a WiCAN reports on its /status endpoint.
+
+    Args:
+        hass: The Home Assistant instance.
+        urls: Base URLs to try, in order, until one answers.
+
+    Returns:
+        The reported device_id, or None if no URL answered with one.
+    """
+    session = async_get_clientsession(hass)
+    for url in urls:
+        if not url:
+            continue
+
+        status_url = f"{url.rstrip('/')}/status"
+        try:
+            async with session.get(status_url, timeout=STATUS_TIMEOUT) as response:
+                if response.status != HTTPStatus.OK:
+                    _LOGGER.debug("Status request to %s returned HTTP %s", status_url, response.status)
+                    continue
+                status = await response.json(content_type=None)
+        except (TimeoutError, aiohttp.ClientError, ValueError) as err:
+            _LOGGER.debug("Could not read device_id from %s: %s", status_url, err)
+            continue
+
+        device_id = status.get("device_id") if isinstance(status, dict) else None
+        if device_id:
+            return str(device_id)
+
+        _LOGGER.debug("No device_id in the status reported by %s", status_url)
+
+    return None
 
 
 def _format_http_url(address: str | None, port: int | None) -> str | None:

--- a/custom_components/wican/config_flow.py
+++ b/custom_components/wican/config_flow.py
@@ -83,6 +83,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 entry_data.get("mdns"),
             )
             if device_id:
+                if self._device_id_configured(device_id):
+                    return self.async_abort(reason="already_configured")
                 entry_data["device_id"] = device_id
                 await self.async_set_unique_id(device_id)
                 self._abort_if_unique_id_configured()
@@ -140,6 +142,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             base_id = hostname if hostname else name
             unique_id = f"{base_id}-{host}:{port}"
             _LOGGER.debug("Using hostname-based unique_id: %s", unique_id)
+
+        # A device added manually is keyed on its device_id, so its unique id
+        # does not match the MAC preferred here.  Compare the device_id itself
+        # to recognize the device whichever way it was added first.
+        if device_id and self._device_id_configured(device_id):
+            return self.async_abort(reason="already_configured")
 
         await self.async_set_unique_id(unique_id)
         self._abort_if_unique_id_configured()
@@ -202,6 +210,21 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 "name": self.discovered_name or "WiCAN",
                 "url": self.discovered_mdns or self.discovered_host or "Unknown",
             },
+        )
+
+    @callback
+    def _device_id_configured(self, device_id: str) -> bool:
+        """Return whether an entry already holds this device_id.
+
+        Args:
+            device_id: The device_id reported by the device.
+
+        Returns:
+            True if a configured entry belongs to that device.
+        """
+        return any(
+            entry.data.get("device_id") == device_id
+            for entry in self._async_current_entries(include_ignore=False)
         )
 
     @staticmethod

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import aiohttp
 import pytest
 
 from homeassistant import config_entries
@@ -15,6 +17,42 @@ from homeassistant.const import CONF_NAME, CONF_WEBHOOK_ID
 from custom_components.wican.const import DOMAIN
 
 from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+
+def _status_session(
+    *,
+    device_id: str | None = None,
+    error: Exception | None = None,
+) -> MagicMock:
+    """Return a mock client session answering the WiCAN /status endpoint."""
+    session = MagicMock()
+    if error is not None:
+        session.get = MagicMock(side_effect=error)
+        return session
+
+    response = MagicMock()
+    response.status = 200
+    response.json = AsyncMock(
+        return_value={"device_id": device_id} if device_id else {},
+    )
+    request = MagicMock()
+    request.__aenter__ = AsyncMock(return_value=response)
+    request.__aexit__ = AsyncMock(return_value=False)
+    session.get = MagicMock(return_value=request)
+    return session
+
+
+@pytest.fixture(autouse=True)
+def mock_status_unreachable() -> Generator[MagicMock]:
+    """Make the manual flow's status request fail unless a test says otherwise."""
+    with patch(
+        "custom_components.wican.config_flow.async_get_clientsession",
+        return_value=_status_session(error=aiohttp.ClientError("unreachable")),
+    ) as mock_session:
+        yield mock_session
 
 
 async def test_user_flow_success(
@@ -81,6 +119,81 @@ async def test_user_flow_adds_http_scheme(
 
     assert result2["type"] == FlowResultType.CREATE_ENTRY
     assert result2["data"]["mdns"] == "http://wican_test.local"
+
+
+async def test_user_flow_fetches_device_id(hass: HomeAssistant) -> None:
+    """Test the manual flow stores the device_id the device reports."""
+    session = _status_session(device_id="abc123")
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+    )
+
+    with (
+        patch(
+            "custom_components.wican.config_flow.async_get_clientsession",
+            return_value=session,
+        ),
+        patch("custom_components.wican.async_setup_entry", return_value=True),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"mdns": "wican_test.local", "host": "192.168.1.50"},
+        )
+
+    await hass.async_block_till_done()
+
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["data"]["device_id"] == "abc123"
+    assert result2["result"].unique_id == "abc123"
+    # The host is the more reliable address, so it is tried first.
+    assert session.get.call_args.args[0] == "http://192.168.1.50/status"
+
+
+async def test_user_flow_status_unreachable(hass: HomeAssistant) -> None:
+    """Test the manual flow still creates the entry when /status does not answer."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+    )
+
+    with patch("custom_components.wican.async_setup_entry", return_value=True):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"mdns": "wican_test.local"},
+        )
+
+    await hass.async_block_till_done()
+
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert "device_id" not in result2["data"]
+    assert result2["result"].unique_id is None
+
+
+async def test_user_flow_duplicate_device_id_aborts(hass: HomeAssistant) -> None:
+    """Test the manual flow aborts when the device is already configured."""
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="abc123",
+        data={CONF_WEBHOOK_ID: "existing", "device_id": "abc123"},
+    ).add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+    )
+
+    with patch(
+        "custom_components.wican.config_flow.async_get_clientsession",
+        return_value=_status_session(device_id="abc123"),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"mdns": "wican_test.local"},
+        )
+
+    assert result2["type"] == FlowResultType.ABORT
+    assert result2["reason"] == "already_configured"
 
 
 async def test_zeroconf_flow_success(

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -196,6 +196,73 @@ async def test_user_flow_duplicate_device_id_aborts(hass: HomeAssistant) -> None
     assert result2["reason"] == "already_configured"
 
 
+async def test_user_flow_aborts_for_zeroconf_added_device(hass: HomeAssistant) -> None:
+    """Test the manual flow recognizes a device already added over zeroconf."""
+    # Zeroconf keys its entries on the MAC, which is not the device_id, so only
+    # the stored device_id identifies the device across both flows.
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="aabbccddeeff",
+        data={
+            CONF_WEBHOOK_ID: "existing_webhook",
+            "mac": "AA:BB:CC:DD:EE:FF",
+            "device_id": "aabbccddef00",
+        },
+    ).add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+    )
+
+    with patch(
+        "custom_components.wican.config_flow.async_get_clientsession",
+        return_value=_status_session(device_id="aabbccddef00"),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"mdns": "wican_test.local"},
+        )
+
+    assert result2["type"] == FlowResultType.ABORT
+    assert result2["reason"] == "already_configured"
+
+
+async def test_zeroconf_aborts_for_manually_added_device(hass: HomeAssistant) -> None:
+    """Test zeroconf recognizes a device already added manually."""
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="aabbccddef00",
+        data={
+            CONF_WEBHOOK_ID: "existing_webhook",
+            "mdns": "http://wican_test.local",
+            "device_id": "aabbccddef00",
+        },
+    ).add_to_hass(hass)
+
+    discovery_info = ZeroconfServiceInfo(
+        ip_address="192.168.1.100",
+        ip_addresses=["192.168.1.100"],
+        hostname="wican_test.local.",
+        name="WiCAN-WebServer._wican._tcp.local.",
+        port=80,
+        type="_wican._tcp.local.",
+        properties={
+            "mac": b"AA:BB:CC:DD:EE:FF",
+            "device_id": b"aabbccddef00",
+        },
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_ZEROCONF},
+        data=discovery_info,
+    )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
 async def test_zeroconf_flow_success(
     hass: HomeAssistant,
     mock_aiohttp_session,


### PR DESCRIPTION
The two flows key their entries differently.  Zeroconf prefers the MAC
from the mDNS TXT records, which the firmware reads from the station
interface, while a manual entry is keyed on the device_id, which is the
soft AP address of the same radio.  Those are two different addresses,
so neither flow's _abort_if_unique_id_configured() sees the entry the
other flow created and the device ends up configured twice, with two
webhooks and a duplicate set of entities.

Both flows now also compare the device_id itself, which both of them
store on the entry, against the entries already configured.  That
identifies the device whichever way it was added first, without changing
the unique id of any entry that exists today.

This is stacked on #100